### PR TITLE
Rule Category Update / Bug Fix / Fixing UDR Service Integration Test

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/udr/json/MetaDataBuilder.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/udr/json/MetaDataBuilder.java
@@ -1,0 +1,74 @@
+package gov.gtas.model.udr.json;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import gov.gtas.constant.RuleConstants;
+
+import java.util.Date;
+
+public class MetaDataBuilder {
+
+    private String title;
+    private String description;
+    private Long ruleCat;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RuleConstants.UDR_DATE_FORMAT)
+    private Date startDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RuleConstants.UDR_DATE_FORMAT)
+    private Date endDate;
+    private String author;
+    private boolean enabled;
+
+
+    public MetaDataBuilder title(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public MetaDataBuilder description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public MetaDataBuilder ruleCat(Long ruleCat) {
+        this.ruleCat = ruleCat;
+        return this;
+    }
+
+    public MetaDataBuilder startDate(Date startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    public MetaDataBuilder endDate(Date endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    public MetaDataBuilder author(String author) {
+        this.author = author;
+        return this;
+    }
+
+    public MetaDataBuilder enabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public MetaData build() {
+        MetaData metaData = new MetaData();
+        metaData.setTitle(this.title);
+        metaData.setDescription(this.description);
+        metaData.setRuleCat(this.ruleCat);
+        metaData.setStartDate(this.startDate);
+        metaData.setEndDate(this.endDate);
+        metaData.setAuthor(this.author);
+        metaData.setEnabled(this.enabled);
+        return metaData;
+    }
+
+
+
+
+
+
+
+}

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/RuleCatRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/RuleCatRepository.java
@@ -7,8 +7,14 @@ package gov.gtas.repository;
 
 
 import gov.gtas.model.lookup.RuleCat;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface RuleCatRepository extends CrudRepository<RuleCat, Long> {
 
+    @Query("SELECT rc FROM RuleCat rc where rc.catId = :catId" )
+    List<RuleCat> findRuleCatByCatId(@Param("catId") Long catId);
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/RuleCatService.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/RuleCatService.java
@@ -9,12 +9,14 @@ import gov.gtas.model.lookup.RuleCat;
 
 public interface RuleCatService {
 
-    public RuleCat findRuleCatByID(Long id);
+    RuleCat findRuleCatByID(Long id);
 
-    public Iterable<RuleCat> findAll();
+    RuleCat findRuleCatByCatId(Long catId);
 
-    public Long fetchRuleCatPriorityIdFromRuleId(Long ruleId) throws Exception;
+    Iterable<RuleCat> findAll();
 
-    public Long fetchRuleCatIdFromRuleId(Long ruleId) throws Exception;
+    Long fetchRuleCatPriorityIdFromRuleId(Long ruleId) throws Exception;
+
+    Long fetchRuleCatIdFromRuleId(Long ruleId) throws Exception;
 
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/RuleCatServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/RuleCatServiceImpl.java
@@ -9,6 +9,8 @@ import gov.gtas.model.lookup.RuleCat;
 import gov.gtas.model.udr.UdrRule;
 import gov.gtas.repository.RuleCatRepository;
 import gov.gtas.repository.udr.UdrRuleRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
@@ -19,6 +21,8 @@ import java.util.Set;
 @Service
 public class RuleCatServiceImpl implements RuleCatService {
 
+    private static final Logger logger = LoggerFactory
+            .getLogger(RuleCatServiceImpl.class);
 
     @Resource
     private RuleCatRepository ruleCatRepository;
@@ -29,6 +33,19 @@ public class RuleCatServiceImpl implements RuleCatService {
     @Override
     public RuleCat findRuleCatByID(Long id) {
         return ruleCatRepository.findOne(id);
+    }
+
+    @Override
+    public RuleCat findRuleCatByCatId(Long id) {
+        List<RuleCat> ruleCatList = ruleCatRepository.findRuleCatByCatId(id);
+        RuleCat ruleCat;
+        if (ruleCatList.isEmpty()) {
+            ruleCat = null;
+            logger.error("Unable to find rule category of " + id + " catId");
+        } else {
+            ruleCat = ruleCatList.get(0);
+        }
+        return ruleCat;
     }
 
     @Override

--- a/gtas-parent/gtas-commons/src/test/java/gov/gtas/services/RuleCatServiceImplTest.java
+++ b/gtas-parent/gtas-commons/src/test/java/gov/gtas/services/RuleCatServiceImplTest.java
@@ -7,6 +7,7 @@ package gov.gtas.services;
 
 
 import gov.gtas.config.CommonServicesConfig;
+import gov.gtas.model.lookup.RuleCat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,16 +18,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import javax.validation.constraints.NotNull;
-
-import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.assertEquals;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { CommonServicesConfig.class })
+@ContextConfiguration(classes = {CommonServicesConfig.class})
 public class RuleCatServiceImplTest {
 
     private static final Logger logger = LoggerFactory
             .getLogger(RuleCatServiceImplTest.class);
+
     @Before
     public void setUp() throws Exception {
     }
@@ -40,9 +40,25 @@ public class RuleCatServiceImplTest {
 
 
     @Test
-    public void testRuleCatRetrieval() throws Exception{
+    public void testRuleCatRetrievalTerroism() {
+        RuleCat ruleCat = ruleCatService.findRuleCatByCatId(2L);
+        assertEquals(ruleCat.getCatId(), new Long(2L));
+        assertEquals(ruleCat.getCategory(), "Terrorism");
+    }
 
-    //assertTrue(ruleCatService.findRuleCatByID(new Long(2)).getCatId()!=null);
+
+    @Test
+    public void testRuleCatRetrievalGeneral() {
+        RuleCat ruleCat = ruleCatService.findRuleCatByCatId(1L);
+        assertEquals(ruleCat.getCatId(), new Long(1L));
+        assertEquals(ruleCat.getCategory(), "General");
+    }
+
+    @Test
+    public void testRuleCatDoesntExist() {
+        long notAValidRuleCategory = -1999L;
+        RuleCat ruleCat = ruleCatService.findRuleCatByCatId(notAValidRuleCategory);
+        assertEquals(ruleCat, null);
     }
 
 }

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/svc/UdrServiceImpl.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/svc/UdrServiceImpl.java
@@ -526,21 +526,17 @@ public class UdrServiceImpl implements UdrService {
 	// Utility method to retrieve RuleCat Set from nested RuleMeta under UDR Rule
 	private void setRuleCatOnRuleMeta(RuleMeta ruleMeta) {
 
-		Set<RuleCat> _tempRuleCatSet = ruleMeta.getRuleCategories();
-
-		RuleCat _tempRuleCat = _tempRuleCatSet.stream()
-				.filter(x -> x.getId()!=null)
+		RuleCat ruleCat = ruleMeta
+				.getRuleCategories()
+				.stream()
+				.filter(rc -> rc.getId() != null)
 				.findAny()
-				.orElse(null);
+				.orElse(ruleCatService.findRuleCatByCatId(1L)); //Default to 1L - "General Rule Category"
 
-		if(_tempRuleCat==null){ // if category is missing, set it to "General" category
-			_tempRuleCat= ruleCatService.findRuleCatByCatId(1L);
-		}
 		//finally, retrieve this category object and set it in UDRrule for persistence
-		_tempRuleCat = ruleCatService.findRuleCatByID(_tempRuleCat.getId());
-		_tempRuleCatSet = new HashSet<>();
-		_tempRuleCatSet.add(_tempRuleCat);
-		ruleMeta.setRuleCategories(_tempRuleCatSet);
-
+		ruleCat = ruleCatService.findRuleCatByID(ruleCat.getId());
+		Set<RuleCat> ruleCatSet = new HashSet<>();
+		ruleCatSet.add(ruleCat);
+		ruleMeta.setRuleCategories(ruleCatSet);
 	}
 }

--- a/gtas-parent/gtas-webapp/src/main/webapp/build/build.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/build/build.html
@@ -63,11 +63,10 @@
         <md-datepicker ng-model="rule.endDate" md-placeholder="End Date"></md-datepicker>
       </div>
       <div class="mdl-selectfield mdl-js-selectfield" data-upgraded=",MaterialSelectfield">
-        <select class="cbp-non-chip-input mdl-selectfield__select" id="disposition"
-          ng-model="rule.ruleCat">
-          <option ng-repeat="rule in ruleCategories" value="{{rule.id}}" translate>
-            {{rule.category}}
-          </option>
+         <select class="cbp-non-chip-input mdl-selectfield__select"
+                  id="disposition"
+                  ng-model="rule.ruleCat"
+                  ng-options="rule.id as rule.category for rule in ruleCategories">
         </select>
         <label class="mdl-selectfield__label static-label" for="disposition">Rule Categories:</label>
       </div>


### PR DESCRIPTION
1) UDRServiceImpl will attempt to set a rule category id of general when no rule category is provided. There was a bug where it would attempt to look up by primary key of 1L instead of category id of 1L when there was no rule category given. This caused errors when the primary key of the general rule was not 1L as it would then attempt to update the meta data with no rule category causing a database violation/exception. The code logic would also only update part of the meta data if it was not run under a "query" tag. I changed this to update with the rest of the meta data. 

This implementation will make two queries to the database when a user doesn't select a value. I think the performance loss will be minimal as the rule_category table will likely be very small. I did consider switching catId to represent the catId instead of it id of rule_category from the database but saw other instances, such as cases, that use the primary key so I kept it pulling from the id. I did make a different implementation calling the db only once but using the catId as the differences are trivial.

2) The build.html would not display the rule category for rules. This was because of two reasons. The first was options does not pick up the initial value in the model. The second was because the rule id (in ruleCat) wasn't being sent back from the server. I changed this to come back from the server and I used ng-options to display what rule category was selected. 

Light testing, including passing untit test in udrservive it, and manually testing by creating, updating, deleting, and adding/deleting queries was performed.

<!---
@huboard:{"milestone_order":1.70721194424964e-11,"order":882}
-->
