### PR TITLE
Passenger Details Controller Null Pointer On Agency With No ID #917

### DIFF
--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/PassengerDetailsController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/PassengerDetailsController.java
@@ -758,7 +758,7 @@ public class PassengerDetailsController {
 				
 				//Agency
 				for(AgencyVo a: targetVo.getAgencies()) {
-					if(currString.contains(a.getIdentifier())) {
+					if(a.getIdentifier() != null && currString.contains(a.getIdentifier())) {
 						segment.append("AGEN");
 						segment.append(a.getIdentifier());
 						segment.append(" ");


### PR DESCRIPTION
Added null check as a AgencyVo can have a null identifier.