### PR TITLE
#912 Conservative fix for fixing lines that end in "UNT'" by stopping

### DIFF
--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/edifact/EdifactLexer.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/edifact/EdifactLexer.java
@@ -39,12 +39,18 @@ public final class EdifactLexer {
      *         does not exist.
      */
     public int getStartOfSegment(String segmentName) {
-        String format = "%s\\s*(\\%c|\\%c)";
+        String format;
+        String regex;
         if (segmentName.equalsIgnoreCase("UNT")) {
-            format = "%s\\s*(\\%c[0-9]|\\%c)";
+            format = "%s\\s*(\\%c[0-9])";
+            regex = String.format(format, segmentName,
+                    this.una.getDataElementSeparator());
+        } else {
+            format = "%s\\s*(\\%c|\\%c)";
+            regex = String.format(format, segmentName,
+                    this.una.getDataElementSeparator(),
+                    this.una.getSegmentTerminator());
         }
-        String regex = String.format(format, segmentName, this.una.getDataElementSeparator(),
-                this.una.getSegmentTerminator());
         return TextUtils.indexOfRegex(regex, this.message);
     }
     


### PR DESCRIPTION
regex expression that looks for UNT'.

Tested PNR that failed as well as all PNRs dev developed against. 