### PR TITLE
Issue #837

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/vo/FlightQueryVo.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/vo/FlightQueryVo.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class FlightQueryVo {
     List<Flight> flights;
     long totalFlights;
+    private boolean queryLimitReached;
     
     public List<Flight> getFlights() {
         return flights;
@@ -24,5 +25,13 @@ public class FlightQueryVo {
     }
     public void setTotalFlights(long totalFlights) {
         this.totalFlights = totalFlights;
+    }
+
+    public boolean isQueryLimitReached() {
+        return queryLimitReached;
+    }
+
+    public void setQueryLimitReached(boolean queryLimitReached) {
+        this.queryLimitReached = queryLimitReached;
     }
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/vo/PassengerQueryVo.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/vo/PassengerQueryVo.java
@@ -10,6 +10,8 @@ import java.util.List;
 public class PassengerQueryVo {
     List<Object[]> result;
     long totalPassengers;
+    private boolean queryLimitReached;
+
     public List<Object[]> getResult() {
         return result;
     }
@@ -22,5 +24,12 @@ public class PassengerQueryVo {
     public void setTotalPassengers(long totalPassengers) {
         this.totalPassengers = totalPassengers;
     }
-    
+
+    public boolean isQueryLimitReached() {
+        return queryLimitReached;
+    }
+
+    public void setQueryLimitReached(boolean queryLimitReached) {
+        this.queryLimitReached = queryLimitReached;
+    }
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/AppConfigurationRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/AppConfigurationRepository.java
@@ -20,6 +20,8 @@ public interface AppConfigurationRepository extends CrudRepository<AppConfigurat
     public static String DASHBOARD_AIRPORT = "DASHBOARD_AIRPORT";
     public static String SMS_TOPIC_ARN = "SMS_TOPIC_ARN";
     public static String MATCHING_THRESHOLD = "MATCHING_THRESHOLD";
+    public static String MAX_PASSENGER_QUERY_RESULT = "MAX_PASSENGER_QUERY_RESULT";
+    public static String MAX_FLIGHT_QUERY_RESULT = "MAX_FLIGHT_QUERY_RESULT";
     public static String FLIGHT_RANGE = "FLIGHT_RANGE";
     public static String REDIS_KEYS_TTL = "REDIS_KEYS_TTL";
     public static String REDIS_KEYS_TTL_TIME_UNIT = "REDIS_KEYS_TTL_TIME_UNIT";

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/dto/FlightsPageDto.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/dto/FlightsPageDto.java
@@ -11,15 +11,30 @@ import gov.gtas.vo.passenger.FlightVo;
 
 public class FlightsPageDto {
     private List<FlightVo> flights;
+    private boolean queryLimitReached;
     private long totalFlights;
     public FlightsPageDto(List<FlightVo> flights, long totalFlights) {
+        this(flights, totalFlights, false);
+    }
+
+    public FlightsPageDto(List<FlightVo> flights, long totalFlights, boolean queryLimitReached) {
         this.flights = flights;
         this.totalFlights = totalFlights;
+        this.queryLimitReached = queryLimitReached;
     }
+
     public List<FlightVo> getFlights() {
         return flights;
     }
     public long getTotalFlights() {
         return totalFlights;
+    }
+
+    public boolean isQueryLimitReached() {
+        return queryLimitReached;
+    }
+
+    public void setQueryLimitReached(boolean queryLimitReached) {
+        this.queryLimitReached = queryLimitReached;
     }
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/dto/PassengersPageDto.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/dto/PassengersPageDto.java
@@ -12,14 +12,27 @@ import gov.gtas.vo.passenger.PassengerVo;
 public class PassengersPageDto {
     private List<PassengerVo> passengers;
     private long totalPassengers;
+    private boolean queryLimitReached;
     public PassengersPageDto(List<PassengerVo> passengers, long totalPassengers) {
+        this(passengers, totalPassengers, false);
+    }
+    public PassengersPageDto(List<PassengerVo> passengers, long totalPassengers, boolean queryLimitReached) {
         this.passengers = passengers;
         this.totalPassengers = totalPassengers;
+        this.queryLimitReached = queryLimitReached;
     }
     public List<PassengerVo> getPassengers() {
         return passengers;
     }
     public long getTotalPassengers() {
         return totalPassengers;
+    }
+
+    public boolean isQueryLimitReached() {
+        return queryLimitReached;
+    }
+
+    public void setQueryLimitReached(boolean queryLimitReached) {
+        this.queryLimitReached = queryLimitReached;
     }
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/vo/SettingsVo.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/vo/SettingsVo.java
@@ -7,6 +7,8 @@ package gov.gtas.vo;
 
 public class SettingsVo {
     private double matchingThreshold;
+    private int maxPassengerQueryResult;
+    private int maxFlightQueryResult;
     private double flightRange;
     private String apisOnlyFlag;
     private String apisVersion;
@@ -39,7 +41,21 @@ public class SettingsVo {
     public void setApisVersion(String apisVersion) {
         this.apisVersion = apisVersion;
     }
-        
-        
-	
+
+
+    public int getMaxPassengerQueryResult() {
+        return maxPassengerQueryResult;
+    }
+
+    public void setMaxPassengerQueryResult(int maxPassengerQueryResult) {
+        this.maxPassengerQueryResult = maxPassengerQueryResult;
+    }
+
+    public int getMaxFlightQueryResult() {
+        return maxFlightQueryResult;
+    }
+
+    public void setMaxFlightQueryResult(int maxFlightQueryResult) {
+        this.maxFlightQueryResult = maxFlightQueryResult;
+    }
 }

--- a/gtas-parent/gtas-commons/src/main/resources/sql/gtas_data.sql
+++ b/gtas-parent/gtas-commons/src/main/resources/sql/gtas_data.sql
@@ -56,6 +56,8 @@ insert into app_configuration (opt, val, description) values('HOURLY_ADJ','-5','
 insert into app_configuration (opt, val, description) values('DASHBOARD_AIRPORT','IAD','Dashboard Airport');
 insert into app_configuration (opt, val, description) values('SMS_TOPIC_ARN','','The ARN of the topic used by SmsService');
 insert into app_configuration (opt, val, description) values('MATCHING_THRESHOLD','.70','Threshold which to determine name match');
+insert into app_configuration (opt, val, description) values('MAX_PASSENGER_QUERY_RESULT','1000','Maximum amount of passenger results from query allowed');
+insert into app_configuration (opt, val, description) values('MAX_FLIGHT_QUERY_RESULT','1000','Maximum amount of flight results from query allowed');
 insert into app_configuration (opt, val, description) values('FLIGHT_RANGE','3','Time range for adding flights to name matching queue');
 insert into app_configuration (opt, val, description) values('REDIS_KEYS_TTL','5','Number of days indexed REDIS Keys to expire in');
 insert into app_configuration (opt, val, description) values('REDIS_KEYS_TTL_TIME_UNIT','DAYS','REDIS keys expiration time units - DAYS or MINUTES ');

--- a/gtas-parent/gtas-query-builder/src/main/java/gov/gtas/querybuilder/service/QueryBuilderService.java
+++ b/gtas-parent/gtas-query-builder/src/main/java/gov/gtas/querybuilder/service/QueryBuilderService.java
@@ -8,7 +8,6 @@ package gov.gtas.querybuilder.service;
 import static gov.gtas.constant.GtasSecurityConstants.PRIVILEGES_ADMIN_AND_MANAGE_QUERIES;
 
 import gov.gtas.enumtype.EntityEnum;
-import gov.gtas.model.BookingDetail;
 import gov.gtas.model.Flight;
 import gov.gtas.model.Passenger;
 import gov.gtas.model.User;
@@ -136,8 +135,6 @@ public class QueryBuilderService {
 
 	@PreAuthorize(PRIVILEGES_ADMIN_AND_MANAGE_QUERIES)
 	public FlightsPageDto runFlightQuery(QueryRequest queryRequest) throws InvalidQueryException {
-		List<FlightVo> flightList = new ArrayList<>();
-		long totalCount = 0;
 
 		// validate queryRequest
 		if (queryRequest == null) {
@@ -151,9 +148,12 @@ public class QueryBuilderService {
 			throw new InvalidQueryException(errorMsg, queryRequest.getQuery());
 		}
 
+		List<FlightVo> flightList = new ArrayList<>();
+		long totalCount = 0;
+		boolean queryLimitReached;
 		try {
 			FlightQueryVo flights = queryRepository.getFlightsByDynamicQuery(queryRequest);
-
+			queryLimitReached = flights.isQueryLimitReached();
 			if (flights == null) {
 				return new FlightsPageDto(flightList, totalCount);
 			}
@@ -172,13 +172,12 @@ public class QueryBuilderService {
 			throw new InvalidQueryException(e.getMessage(), queryRequest.getQuery());
 		}
 
-		return new FlightsPageDto(flightList, totalCount);
+		return new FlightsPageDto(flightList, totalCount, queryLimitReached);
 	}
 
 	@PreAuthorize(PRIVILEGES_ADMIN_AND_MANAGE_QUERIES)
 	public PassengersPageDto runPassengerQuery(QueryRequest queryRequest) throws InvalidQueryException {
-		List<PassengerVo> passengerList = new ArrayList<>();
-		long totalCount = 0;
+
 
 		// validate queryRequest
 		if (queryRequest == null) {
@@ -191,9 +190,12 @@ public class QueryBuilderService {
 			logger.info(errorMsg, new InvalidQueryException(errorMsg, queryRequest.getQuery()));
 			throw new InvalidQueryException(errorMsg, queryRequest.getQuery());
 		}
-
+		List<PassengerVo> passengerList = new ArrayList<>();
+		long totalCount = 0;
+		boolean queryLimitReached;
 		try {
 			PassengerQueryVo resultList = queryRepository.getPassengersByDynamicQuery(queryRequest);
+			queryLimitReached = resultList.isQueryLimitReached();
 			if (resultList == null) {
 				return new PassengersPageDto(passengerList, totalCount);
 			}
@@ -227,7 +229,7 @@ public class QueryBuilderService {
 			throw new InvalidQueryException(e.getMessage(), queryRequest.getQuery());
 		}
 
-		return new PassengersPageDto(passengerList, totalCount);
+		return new PassengersPageDto(passengerList, totalCount, queryLimitReached);
 	}
 
 	private UserQuery createUserQuery(String userId, UserQueryRequest req) throws JsonProcessingException {

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/AdminController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/AdminController.java
@@ -11,7 +11,6 @@ import gov.gtas.error.ErrorDetailInfo;
 import gov.gtas.model.ApiAccess;
 import gov.gtas.model.AuditRecord;
 import gov.gtas.model.lookup.AppConfiguration;
-import gov.gtas.repository.AppConfigurationRepository;
 import gov.gtas.services.AppConfigurationService;
 import gov.gtas.services.ApiAccessService;
 import gov.gtas.services.AuditLogPersistenceService;
@@ -44,6 +43,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import static gov.gtas.repository.AppConfigurationRepository.MAX_FLIGHT_QUERY_RESULT;
+import static gov.gtas.repository.AppConfigurationRepository.MAX_PASSENGER_QUERY_RESULT;
 
 /**
  * Back-end REST service interface to support audit/error log viewing and
@@ -139,7 +141,9 @@ public class AdminController {
 		SettingsVo settingsVo = new SettingsVo();
 		settingsVo.setMatchingThreshold(Double.parseDouble(appConfigurationService.findByOption(MATCHING_THRESHOLD).getValue()));
 		settingsVo.setFlightRange(Double.parseDouble(appConfigurationService.findByOption(FLIGHT_RANGE).getValue()));
-                
+		settingsVo.setMaxPassengerQueryResult(Integer.parseInt(appConfigurationService.findByOption(MAX_PASSENGER_QUERY_RESULT).getValue()));
+		settingsVo.setMaxFlightQueryResult(Integer.parseInt(appConfigurationService.findByOption(MAX_FLIGHT_QUERY_RESULT).getValue()));
+
                 AppConfiguration appConfigApisFlag = appConfigurationService.findByOption(APIS_ONLY_FLAG);
                 if (appConfigApisFlag != null)
                 {
@@ -171,8 +175,16 @@ public class AdminController {
 			appConfig = appConfigurationService.findByOption(FLIGHT_RANGE);
 			appConfig.setValue(String.valueOf(settings.getFlightRange()));
 			appConfigurationService.save(appConfig);
-                        
-                        if (settings.getApisOnlyFlag() != null && !settings.getApisOnlyFlag().isEmpty())
+
+			appConfig = appConfigurationService.findByOption(MAX_PASSENGER_QUERY_RESULT);
+			appConfig.setValue(String.valueOf(settings.getMaxPassengerQueryResult()));
+			appConfigurationService.save(appConfig);
+
+			appConfig = appConfigurationService.findByOption(MAX_FLIGHT_QUERY_RESULT);
+			appConfig.setValue(String.valueOf(settings.getMaxFlightQueryResult()));
+			appConfigurationService.save(appConfig);
+
+			if (settings.getApisOnlyFlag() != null && !settings.getApisOnlyFlag().isEmpty())
                         {
 			    appConfig = appConfigurationService.findByOption(APIS_ONLY_FLAG);
                             if (appConfig != null)

--- a/gtas-parent/gtas-webapp/src/main/webapp/admin/settings.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/admin/settings.html
@@ -5,6 +5,14 @@
       <label class="mdl-textfield__label static-label" for="pass1">Matching Threshold</label>
     </div>
     <div class="mdl-textfield mdl-js-textfield mdl-textfield--full-width">
+      <input class="mdl-textfield__input" type="text" id="pmax1" ng-model="settingsInfo.maxPassengerQueryResult" />
+      <label class="mdl-textfield__label static-label" for="pmax1">Maximum Passenger Query Results</label>
+    </div>
+    <div class="mdl-textfield mdl-js-textfield mdl-textfield--full-width">
+      <input class="mdl-textfield__input" type="text" id="fmax1" ng-model="settingsInfo.maxFlightQueryResult" />
+      <label class="mdl-textfield__label static-label" for="fmax1">Maximum Flight Query Results</label>
+    </div>
+    <div class="mdl-textfield mdl-js-textfield mdl-textfield--full-width">
       <input class="mdl-textfield__input" type="text" id="watch1" ng-model="settingsInfo.flightRange" />
       <label class="mdl-textfield__label static-label" for="watch1">Watchlist Matching Flight Range</label>
     </div>

--- a/gtas-parent/gtas-webapp/src/main/webapp/flights/FlightsController.js
+++ b/gtas-parent/gtas-webapp/src/main/webapp/flights/FlightsController.js
@@ -56,7 +56,7 @@
             setFlightsGrid = function (grid, response) {
                 //NEEDED because java services responses not standardize should have Lola change and Amit revert to what he had;
                 var data = stateName === 'queryFlights' ? response.data.result : response.data;
-                    grid.totalItems = data.totalFlights === -1 ? 0 : data.totalFlights;
+                grid.totalItems = data.totalFlights === -1 ? 0 : data.totalFlights;
                 grid.data = data.flights;
                 if(!data.flights || data.flights.length == 0){
                     $scope.errorToast("No results found for selected filter criteria");

--- a/gtas-parent/gtas-webapp/src/main/webapp/flights/FlightsController.js
+++ b/gtas-parent/gtas-webapp/src/main/webapp/flights/FlightsController.js
@@ -56,7 +56,7 @@
             setFlightsGrid = function (grid, response) {
                 //NEEDED because java services responses not standardize should have Lola change and Amit revert to what he had;
                 var data = stateName === 'queryFlights' ? response.data.result : response.data;
-                grid.totalItems = data.totalFlights === -1 ? 0 : data.totalFlights;
+                    grid.totalItems = data.totalFlights === -1 ? 0 : data.totalFlights;
                 grid.data = data.flights;
                 if(!data.flights || data.flights.length == 0){
                     $scope.errorToast("No results found for selected filter criteria");
@@ -71,6 +71,7 @@
             getPage = function () {
                 if(stateName === 'queryFlights'){
                     setFlightsGrid($scope.flightsQueryGrid, flights || {flights: [], totalFlights: 0});
+                    $scope.queryLimitReached = flights.data.result.queryLimitReached;
                 }
                 else{
                     setFlightsGrid($scope.flightsGrid, flights || {flights: [], totalFlights: 0});

--- a/gtas-parent/gtas-webapp/src/main/webapp/flights/query-flights.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/flights/query-flights.html
@@ -1,4 +1,5 @@
 <h3 class="block-label upper-cnt">Query Results: Flights</h3>
+<h3 ng-if="queryLimitReached" class="block-label upper-cnt">Maximum result reached, data may be truncated</h3>
 <div ng-if="stateName != 'queryFlights'"
         ui-grid="flightsGrid"
         ui-grid-pagination

--- a/gtas-parent/gtas-webapp/src/main/webapp/pax/PaxController.js
+++ b/gtas-parent/gtas-webapp/src/main/webapp/pax/PaxController.js
@@ -436,6 +436,7 @@
             getPage = function () {
                 if(stateName === "queryPassengers"){
                     setPassengersGrid($scope.passengerQueryGrid, passengers);
+                    $scope.queryLimitReached = passengers.data.result.queryLimitReached;
                 }else{
                     setPassengersGrid($scope.passengerGrid, passengers);
                 }

--- a/gtas-parent/gtas-webapp/src/main/webapp/pax/pax.table.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/pax/pax.table.html
@@ -56,6 +56,7 @@
      ng-style="getTableHeight()"
      class="grid"></div>
 <h3 data-ng-if="stateName === 'queryPassengers'"class="block-label upper-cnt">Query Results: Passengers</h3>
+<h3 ng-if="queryLimitReached" class="block-label upper-cnt">Maximum result reached, data may be truncated</h3>
 <div ng-if="stateName === 'queryPassengers'"
      id="grid1" ui-grid="passengerQueryGrid"
      ui-grid-pagination

--- a/gtas-parent/gtas-webapp/src/main/webapp/resources/css/main.css
+++ b/gtas-parent/gtas-webapp/src/main/webapp/resources/css/main.css
@@ -40,9 +40,10 @@ body{
 .gtas-brand:before {
 	content: 'Global Travel Assessment System'
 }
-@media (max-width:550px){
-		.gtas-brand:before {
-	content: 'GTAS'
+@media (max-width:550px) {
+    .gtas-brand:before {
+        content: 'GTAS'
+    }
 }
 	
 [ng\:cloak], [ng-cloak], .ng-cloak {


### PR DESCRIPTION
Set max results on queries to stop long running queries.

Set default max results to 1000 for flights and/or passengers.

Set header to show user when query went over 1000 and data may be truncated.

Updated initial scripts to have values.