### PR TITLE
FK exception when deleting watchlist record from database.

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/watchlist/WatchlistItem.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/watchlist/WatchlistItem.java
@@ -5,11 +5,13 @@
  */
 package gov.gtas.model.watchlist;
 
-import gov.gtas.constant.DomainModelConstants;
 import gov.gtas.model.BaseEntity;
+import gov.gtas.model.PaxWatchlistLink;
 import gov.gtas.model.lookup.WatchlistCategory;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -42,6 +44,9 @@ public class WatchlistItem extends BaseEntity {
 	@ManyToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "Wl_CATEGORY_REF", referencedColumnName = "ID", nullable = true, foreignKey=@ForeignKey(name="FK_Wl_CATEGORY_ID"))
 	private WatchlistCategory watchlistCategory;
+
+	@OneToMany(cascade = CascadeType.REMOVE, mappedBy = "watchlistItem")
+	private Set<PaxWatchlistLink> paxWatchlistLink = new HashSet<>();
 
 	/**
 	 * @return the watch list
@@ -87,19 +92,11 @@ public class WatchlistItem extends BaseEntity {
 	public void setItemRuleData(String itemRuleData) {
 		this.itemRuleData = itemRuleData;
 	}
-	
-	/**
-	 * 
-	 * @return
-	 */
+
 	public WatchlistCategory getWatchlistCategory() {
 		return watchlistCategory;
 	}
 
-	/**
-	 * 
-	 * @param watchlistCategory
-	 */
 	public void setWatchlistCategory(WatchlistCategory watchlistCategory) {
 		this.watchlistCategory = watchlistCategory;
 	}
@@ -119,5 +116,13 @@ public class WatchlistItem extends BaseEntity {
 			return false;
 		final WatchlistItem other = (WatchlistItem) obj;
 		return Objects.equals(this.itemData, other.itemData);
+	}
+
+	public Set<PaxWatchlistLink> getPaxWatchlistLink() {
+		return paxWatchlistLink;
+	}
+
+	public void setPaxWatchlistLink(Set<PaxWatchlistLink> paxWatchlistLink) {
+		this.paxWatchlistLink = paxWatchlistLink;
 	}
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/watchlist/WatchlistPersistenceServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/watchlist/WatchlistPersistenceServiceImpl.java
@@ -30,14 +30,7 @@ import gov.gtas.repository.watchlist.WatchlistRepository;
 import gov.gtas.services.security.UserService;
 import gov.gtas.util.DateCalendarUtils;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
@@ -181,6 +174,7 @@ public class WatchlistPersistenceServiceImpl implements
 	private void doDeleteWithLogging(Watchlist watchlist, User editUser,
 			Collection<WatchlistItem> deleteItems) {
 		if (!CollectionUtils.isEmpty(deleteItems)) {
+			List<WatchlistItem> hydratedDeleteItems = new ArrayList<>();
 			List<AuditRecord> logRecords = new LinkedList<>();
 			Map<Long, WatchlistItem> updateDeleteItemMap = validateItemsPresentInDb(deleteItems);
 			for (WatchlistItem item : deleteItems) {
@@ -189,8 +183,9 @@ public class WatchlistPersistenceServiceImpl implements
 				logRecords.add(createAuditLogRecord(AuditActionType.DELETE_WL,
 						watchlist, itemToDelete, WATCHLIST_LOG_DELETE_MESSAGE,
 						editUser));
+				hydratedDeleteItems.add(itemToDelete);
 			}
-			watchlistItemRepository.deleteAll(deleteItems);
+			watchlistItemRepository.deleteAll(hydratedDeleteItems);
 			auditRecordRepository.saveAll(logRecords);
 		}
 	}


### PR DESCRIPTION
While this will solve the issue of a watchlist item being undeleteable in a fuzzy matching situation it will also delete any fuzzy matches associated with the watchlist item (although not cases).

In order to delete the fuzzy match must be deleted from database as well.

This will *not* delete any cases created from the fuzzy matching hit.

