### PR TITLE
Updated Booking Date to pull data from RCI segment. Resolves #873

### DIFF
--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/pnrgov/PnrGovParser.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/pnrgov/PnrGovParser.java
@@ -78,7 +78,9 @@ public final class PnrGovParser extends EdifactParser<PnrVo> {
 
         DAT_G1 dat = getConditionalSegment(DAT_G1.class, "DAT");
         if (dat != null) {
-            parsedMessage.setDateBooked(dat.getTicketIssueDate());
+        	if (parsedMessage.getDateBooked() == null) {
+                parsedMessage.setDateBooked(dat.getTicketIssueDate());
+            }
             parsedMessage.setDateReceived(dat.getPnrTransactionDate());
         }
 
@@ -164,6 +166,7 @@ public final class PnrGovParser extends EdifactParser<PnrVo> {
             parsedMessage.setRecordLocator(controlInfo.getReservationControlNumber());
             if(controlInfo.getTimeCreated() != null){
                 parsedMessage.setReservationCreateDate(controlInfo.getTimeCreated());
+                parsedMessage.setDateBooked(controlInfo.getTimeCreated());
             }
         }
     }

--- a/gtas-parent/gtas-parsers/src/test/java/gov/gtas/parsers/pnrgov/PnrGovParserTest.java
+++ b/gtas-parent/gtas-parsers/src/test/java/gov/gtas/parsers/pnrgov/PnrGovParserTest.java
@@ -61,7 +61,7 @@ public class PnrGovParserTest implements ParserTestHelper {
         String message77 = getMessageText(PNR_MESSAGE_PG_77);
         PnrVo vo = this.parser.parse(message77);
         LocalDateTime dateBooked = getLocalDateTime(vo.getDateBooked());
-        LocalDateTime May23rd2013At212400 = LocalDateTime.of(2013, 5, 23, 21, 24);
+        LocalDateTime May23rd2013At212400 = LocalDateTime.of(2013, 5, 23, 18, 13, 48);
         assertTrue(May23rd2013At212400.isEqual(dateBooked));
     }
 
@@ -70,7 +70,7 @@ public class PnrGovParserTest implements ParserTestHelper {
         String message76 = getMessageText(PNR_MESSAGE_PG_76);
         PnrVo vo = this.parser.parse(message76);
         LocalDate dateBooked = getLocalDate(vo.getDateBooked());
-        LocalDate Feb142013 = LocalDate.of(2013, 2, 14);
+        LocalDate Feb142013 = LocalDate.of(2013, 2, 15);
         assertTrue(Feb142013.isEqual(dateBooked));
     }
 


### PR DESCRIPTION
If RCI segment exists and has a date, set Booking Date to be the date
that is fetched from RCI segment; otherwise set it to be
TicketIssueDate.