### PR TITLE
Reintroduce hibernate properties

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/config/CommonServicesConfig.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/config/CommonServicesConfig.java
@@ -5,8 +5,10 @@
  */
 package gov.gtas.config;
 
+import java.beans.PropertyVetoException;
+import java.util.Properties;
+
 import javax.annotation.Resource;
-import javax.naming.NamingException;
 import javax.sql.DataSource;
 
 import org.hibernate.jpa.HibernatePersistenceProvider;
@@ -20,10 +22,11 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.env.Environment;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.jndi.JndiTemplate;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
 
 /**
  * The configuration class can be imported into an XML configuration by:<br>
@@ -33,6 +36,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @Configuration
 @ComponentScan("gov.gtas")
 @PropertySource("classpath:commonservices.properties")
+@PropertySource("classpath:hibernate.properties")
 @PropertySource("file:${catalina.home}/conf/application.properties")
 @EnableJpaRepositories("gov.gtas")
 @EnableTransactionManagement
@@ -42,6 +46,68 @@ public class CommonServicesConfig {
     private static Logger logger = LoggerFactory.getLogger(CommonServicesConfig.class);
 
     private static final String PROPERTY_NAME_ENTITYMANAGER_PACKAGES_TO_SCAN = "entitymanager.packages.to.scan";
+    private static final String PROPERTY_NAME_DATABASE_DRIVER = "hibernate.connection.driver_class";
+    private static final String PROPERTY_NAME_DATABASE_PASSWORD = "hibernate.connection.password";
+    private static final String PROPERTY_NAME_DATABASE_URL = "hibernate.connection.url";
+    private static final String PROPERTY_NAME_DATABASE_USERNAME = "hibernate.connection.username";
+    private static final String PROPERTY_NAME_HIBERNATE_SHOW_SQL = "hibernate.show_sql";
+    private static final String PROPERTY_NAME_HIBERNATE_FORMAT_SQL = "hibernate.format_sql";
+    private static final String PROPERTY_NAME_HIBERNATE_DIALECT = "hibernate.dialect";
+    private static final String PROPERTY_NAME_SECOND_LEVEL_CACHE = "hibernate.cache.use_second_level_cache";
+    private static final String PROPERTY_NAME_HIBERNATE_CACHE_FACTORY = "hibernate.cache.region.factory_class";
+    private static final String PROPERTY_NAME_CONFIGURATION_RESOURCE_PATH = "hibernate.cache.provider_configuration_file_resource_path";
+    private static final String PROPERTY_NAME_HIBERNATE_QUERY_CACHE = "hibernate.cache.use_query_cache";
+    private static final String PROPERTY_NAME_HIBERNATE_USE_MINIMAL_PUTS = "hibernate.cache.use_minimal_puts";
+    private static final String PROPERTY_NAME_SHAREDCACHE_MODE = "javax.persistence.sharedCache.mode";
+    private static final String PROPERTY_NAME_HIBERNATE_JDBC_BATCH_SIZE = "hibernate.jdbc.batch_size";
+    private static final String PROPERTY_NAME_HIBERNATE_USE_SQL_COMMENTS = "hibernate.use_sql_comments";
+    private static final String PROPERTY_NAME_HIBERNATE_ORDER_INSERTS = "hibernate.order_inserts";
+    private static final String PROPERTY_NAME_HIBERNATE_ORDER_UPDATES = "hibernate.order_updates";
+    private static final String PROPERTY_NAME_HIBERNATE_JDBC_BATCH_VERSION_DATA = "hibernate.jdbc.batch_versioned_data";
+
+    private static final String PROPERTY_NAME_C3P0_MIN_SIZE = "c3p0.min_size";
+    private static final String PROPERTY_NAME_C3P0_MAX_SIZE = "c3p0.max_size";
+    private static final String PROPERTY_NAME_C3P0_MAX_IDLETIME = "c3p0.max_idletime";
+    private static final String PROPERTY_NAME_C3P0_MAX_STATEMENTS = "c3p0.max_statements";
+    private static final String PROPERTY_NAME_C3P0_MAX_CONNECT = "c3p0.idleConnectionTestPeriod";
+
+    private static final String PROPERTY_NAME_HIBERNATE_CONNECTION_CHARSET = "hibernate.connection.charSet";
+
+    private Properties hibProperties() {
+        Properties properties = new Properties();
+        properties.put(PROPERTY_NAME_HIBERNATE_DIALECT,
+                env.getRequiredProperty(PROPERTY_NAME_HIBERNATE_DIALECT));/*
+        properties.put(PROPERTY_NAME_HIBERNATE_QUERY_CACHE,
+                env.getRequiredProperty(PROPERTY_NAME_HIBERNATE_QUERY_CACHE));
+        properties.put(PROPERTY_NAME_SECOND_LEVEL_CACHE,
+                env.getRequiredProperty(PROPERTY_NAME_SECOND_LEVEL_CACHE));*/
+        properties.put(PROPERTY_NAME_HIBERNATE_FORMAT_SQL,
+                env.getRequiredProperty(PROPERTY_NAME_HIBERNATE_FORMAT_SQL));
+        properties.put(PROPERTY_NAME_HIBERNATE_SHOW_SQL,
+                env.getRequiredProperty(PROPERTY_NAME_HIBERNATE_SHOW_SQL));
+/*
+        properties.put(PROPERTY_NAME_SHAREDCACHE_MODE,
+                env.getRequiredProperty(PROPERTY_NAME_SHAREDCACHE_MODE));
+        properties.put(PROPERTY_NAME_HIBERNATE_USE_MINIMAL_PUTS, env
+                .getRequiredProperty(PROPERTY_NAME_HIBERNATE_USE_MINIMAL_PUTS));*/
+        properties.put(PROPERTY_NAME_HIBERNATE_JDBC_BATCH_SIZE, env
+                .getRequiredProperty(PROPERTY_NAME_HIBERNATE_JDBC_BATCH_SIZE));
+        properties.put(PROPERTY_NAME_HIBERNATE_USE_SQL_COMMENTS, env
+                .getRequiredProperty(PROPERTY_NAME_HIBERNATE_USE_SQL_COMMENTS));
+        properties.put(PROPERTY_NAME_HIBERNATE_ORDER_INSERTS,
+                env.getRequiredProperty(PROPERTY_NAME_HIBERNATE_ORDER_INSERTS));
+        properties.put(PROPERTY_NAME_HIBERNATE_ORDER_UPDATES,
+                env.getRequiredProperty(PROPERTY_NAME_HIBERNATE_ORDER_UPDATES));
+        properties
+                .put(PROPERTY_NAME_HIBERNATE_JDBC_BATCH_VERSION_DATA,
+                        env.getRequiredProperty(PROPERTY_NAME_HIBERNATE_JDBC_BATCH_VERSION_DATA));
+
+        properties
+                .put(PROPERTY_NAME_HIBERNATE_CONNECTION_CHARSET,
+                        env.getRequiredProperty(PROPERTY_NAME_HIBERNATE_CONNECTION_CHARSET));
+
+        return properties;
+    }
 
     @Resource
     private Environment env;
@@ -55,16 +121,32 @@ public class CommonServicesConfig {
 
     @Bean
     public DataSource dataSource() {
-
-    	DataSource dataSource = null;
-
-    	JndiTemplate jndi = new JndiTemplate();
+        // DriverManagerDataSource dataSource mvcn= new DriverManagerDataSource();
+        ComboPooledDataSource dataSource = new ComboPooledDataSource();
     	
     	try {
-    		dataSource = (DataSource) jndi.lookup("java:comp/env/jdbc/gtasDataSource");
-    	} catch(NamingException e) {
-    		logger.error("NamingException for java:comp/env/jdbc/gtasDataSource", e);
+            dataSource.setDriverClass(env
+                    .getRequiredProperty(PROPERTY_NAME_DATABASE_DRIVER));
+        } catch (PropertyVetoException pve) {
+            logger.error("Unable to get required property!", pve);
     	}
+        dataSource.setJdbcUrl(env
+                .getRequiredProperty(PROPERTY_NAME_DATABASE_URL));
+        dataSource.setUser(env
+                .getRequiredProperty(PROPERTY_NAME_DATABASE_USERNAME));
+        dataSource.setPassword(env
+                .getRequiredProperty(PROPERTY_NAME_DATABASE_PASSWORD));
+
+        dataSource.setMinPoolSize(Integer.parseInt(env
+                .getRequiredProperty(PROPERTY_NAME_C3P0_MIN_SIZE)));
+        dataSource.setMaxPoolSize(Integer.parseInt(env
+                .getRequiredProperty(PROPERTY_NAME_C3P0_MAX_SIZE)));
+        dataSource.setMaxIdleTime(Integer.parseInt(env
+                .getRequiredProperty(PROPERTY_NAME_C3P0_MAX_IDLETIME)));
+        dataSource.setMaxStatements(Integer.parseInt(env
+                .getRequiredProperty(PROPERTY_NAME_C3P0_MAX_STATEMENTS)));
+        dataSource.setIdleConnectionTestPeriod(Integer.parseInt(env
+                .getRequiredProperty(PROPERTY_NAME_C3P0_MAX_CONNECT)));
 
     	return dataSource;
     }
@@ -78,6 +160,8 @@ public class CommonServicesConfig {
         entityManagerFactoryBean
                 .setPackagesToScan(env
                         .getRequiredProperty(PROPERTY_NAME_ENTITYMANAGER_PACKAGES_TO_SCAN));
+
+        entityManagerFactoryBean.setJpaProperties(hibProperties());
 
         return entityManagerFactoryBean;
     }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/config/CommonServicesConfig.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/config/CommonServicesConfig.java
@@ -32,7 +32,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 @Configuration
 @ComponentScan("gov.gtas")
-@PropertySource({ "classpath:commonservices.properties" })
+@PropertySource("classpath:commonservices.properties")
+@PropertySource("file:${catalina.home}/conf/application.properties")
 @EnableJpaRepositories("gov.gtas")
 @EnableTransactionManagement
 @Import(AsyncConfig.class)
@@ -51,12 +52,12 @@ public class CommonServicesConfig {
 		pspc.setIgnoreUnresolvablePlaceholders(true);
 		return pspc;
 	}
-    
+
     @Bean
     public DataSource dataSource() {
-    	
+
     	DataSource dataSource = null;
-    	
+
     	JndiTemplate jndi = new JndiTemplate();
     	
     	try {
@@ -64,7 +65,7 @@ public class CommonServicesConfig {
     	} catch(NamingException e) {
     		logger.error("NamingException for java:comp/env/jdbc/gtasDataSource", e);
     	}
-    	
+
     	return dataSource;
     }
 

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/config/CommonServicesConfig.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/config/CommonServicesConfig.java
@@ -37,7 +37,7 @@ import com.mchange.v2.c3p0.ComboPooledDataSource;
 @ComponentScan("gov.gtas")
 @PropertySource("classpath:commonservices.properties")
 @PropertySource("classpath:hibernate.properties")
-@PropertySource("file:${catalina.home}/conf/application.properties")
+@PropertySource(value = "file:${catalina.home}/conf/application.properties", ignoreResourceNotFound = true)
 @EnableJpaRepositories("gov.gtas")
 @EnableTransactionManagement
 @Import(AsyncConfig.class)

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/config/Neo4JConfig.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/config/Neo4JConfig.java
@@ -17,7 +17,8 @@ import javax.annotation.Resource;
 
 @Configuration
 @ComponentScan("gov.gtas")
-@PropertySource({"classpath:commonservices.properties"})
+@PropertySource("classpath:commonservices.properties")
+@PropertySource("file:${catalina.home}/conf/application.properties")
 public class Neo4JConfig {
 
     @Resource

--- a/gtas-parent/gtas-commons/src/main/resources/hibernate.properties
+++ b/gtas-parent/gtas-commons/src/main/resources/hibernate.properties
@@ -1,12 +1,10 @@
 hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 
-#NOTE:Database connection is configured using JNDI (https://github.com/US-CBP/GTAS/issues/1056)
+hibernate.connection.driver_class=org.mariadb.jdbc.Driver
+hibernate.connection.url=jdbc:mariadb://localhost:3306/gtas?useUnicode=true&characterEncoding=UTF-8&createDatabaseIfNotExist=true
 
-#hibernate.connection.driver_class=org.mariadb.jdbc.Driver
-#hibernate.connection.url=jdbc:mariadb://localhost:3306/gtas?useUnicode=true&characterEncoding=UTF-8&createDatabaseIfNotExist=true
-#
-#hibernate.connection.username=root
-#hibernate.connection.password=admin
+hibernate.connection.username=root
+hibernate.connection.password=admin
 
 hibernate.show_sql=false
 hibernate.format_sql=true
@@ -24,13 +22,13 @@ hibernate.cache.use_minimal_puts=true
 hibernate.cache.region.factory_class=com.hazelcast.hibernate.HazelcastCacheRegionFactory
 hibernate.cache.provider_configuration_file_resource_path = classpath:hazelcast.xml
 
-hibernate.id.new_generator_mappings=false 
+hibernate.id.new_generator_mappings=false
 
 javax.persistence.sharedCache.mode = ENABLE_SELECTIVE
 
 c3p0.min_size=3
-c3p0.max_size=20
-c3p0.max_statements=50
+c3p0.max_size=200
+c3p0.max_statements=500
 c3p0.max_idletime=500
 c3p0.idleConnectionTestPeriod=30
 

--- a/gtas-parent/gtas-commons/src/test/java/gov/gtas/services/PnrServiceIT.java
+++ b/gtas-parent/gtas-commons/src/test/java/gov/gtas/services/PnrServiceIT.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import javax.transaction.Transactional;
 
+import gov.gtas.config.CommonServicesConfig;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,7 +26,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import gov.gtas.config.AsyncConfig;
-import gov.gtas.config.TestCommonServicesConfig;
 import gov.gtas.model.Address;
 import gov.gtas.model.Agency;
 import gov.gtas.model.CreditCard;
@@ -41,7 +41,7 @@ import gov.gtas.model.Pnr;
 import gov.gtas.model.lookup.PassengerTypeCode;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { AsyncConfig.class , TestCommonServicesConfig.class})
+@ContextConfiguration(classes = { AsyncConfig.class , CommonServicesConfig.class})
 @Rollback(true)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class PnrServiceIT {

--- a/gtas-parent/gtas-job-scheduler-war/src/main/java/gov/gtas/job/config/JobSchedulerConfig.java
+++ b/gtas-parent/gtas-job-scheduler-war/src/main/java/gov/gtas/job/config/JobSchedulerConfig.java
@@ -22,9 +22,10 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 @Configuration
 @EnableScheduling
 @ComponentScan("gov.gtas.job.scheduler")
-@PropertySource({ "classpath:jobScheduler.properties",
-		"classpath:dashboardJobScheduler.properties",
-		"classpath:singleNodeConfig.json"})
+@PropertySource("classpath:jobScheduler.properties")
+@PropertySource("classpath:dashboardJobScheduler.properties")
+@PropertySource("classpath:singleNodeConfig.json")
+@PropertySource("file:${catalina.home}/conf/application.properties")
 public class JobSchedulerConfig implements SchedulingConfigurer {
 
 	/*

--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/redisson/config/RedisLoaderConfig.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/redisson/config/RedisLoaderConfig.java
@@ -14,7 +14,8 @@ import java.util.concurrent.Executors;
 @Configuration
 @EnableScheduling
 @ComponentScan("gov.gtas.parsers.redisson")
-@PropertySource({ "classpath:redisloader.properties" })
+@PropertySource("classpath:redisloader.properties")
+@PropertySource("file:${catalina.home}/conf/application.properties")
 public class RedisLoaderConfig implements SchedulingConfigurer {
     @Override
     public void configureTasks(ScheduledTaskRegistrar scheduledTaskRegistrar) {


### PR DESCRIPTION
I'd like to reintroduce the database management to hibernate.properties as we will be able to run more integration test and see 

I see some pretty good pros here including the following:
** Allowing for integration test to run which were broken in #1056. Example includes the PNR integration test.

** Allowing application configuration of database to be managed by hibernate and clearly configured within the application code

** One place to look for all application configuration instead of multiple

