### PR TITLE
Fixed grid size, removed ref to missing qbModal element

### DIFF
--- a/gtas-parent/gtas-webapp/src/main/webapp/pax/PaxController.js
+++ b/gtas-parent/gtas-webapp/src/main/webapp/pax/PaxController.js
@@ -570,7 +570,6 @@
     });
 
     $scope.getAttachment = function(paxId) {
-      //TO-DO add specific pax-id here to grab from current passenger
       paxDetailService.getPaxAttachments(paxId).then(function(data) {
         var attList = "";
         $.each(data.data, function(index, value) {
@@ -1141,7 +1140,7 @@
           ruleGridColumns = [{
               name: 'ruleTitle',
               displayName: 'Title',
-              cellTemplate: '<md-button aria-label="title" class="md-primary md-button md-default-theme" ng-click="grid.appScope.ruleIdClick(row)">{{COL_FIELD}}</md-button>'
+              cellTemplate: '<md-button aria-label="title" class="md-primary md-button md-default-theme">{{COL_FIELD}}</md-button>'
           }, {
               name: 'ruleConditions',
               displayName: 'Conditions',
@@ -1256,24 +1255,6 @@
     
           $injector.invoke(jqueryQueryBuilderWidget, this, {$scope: $scope});
           $scope.stateName = $state.$current.self.name;
-          $scope.ruleIdClick = function (row) {
-              $scope.getRuleObject(row.entity.ruleId);
-          };
-          
-        $scope.getRuleObject = function(ruleID) {
-          jqueryQueryBuilderService
-            .loadRuleById("rule", ruleID)
-            .then(function(myData) {
-              $scope.$builder.queryBuilder("readOnlyRules", myData.result.details);
-              $scope.hitDetailDisplay = myData.result.summary.title;
-              document.getElementById("QBModal").style.display = "block";
-    
-              $scope.closeDialog = function() {
-                document.getElementById("QBModal").style.display = "none";
-              };
-            });
-        };
-    
 
     $scope.isExpanded = true;
     $scope.paxHitList = [];
@@ -1287,57 +1268,34 @@
 
     $scope.buildAfterEntitiesLoaded();
 
-      $scope.passengerGrid = {
-              paginationPageSizes: [10, 25, 50],
-              paginationPageSize: 25,
-              paginationCurrentPage: $scope.model.pageNumber,
-              useExternalPagination: false,
-              useExternalSorting: false,
-              useExternalFiltering: false,
-              enableHorizontalScrollbar: 0,
-              enableVerticalScrollbar: 1,
-              enableFiltering: true,
-              enableColumnMenus: false,
-              multiSelect: false,
-              enableGridMenu: true,
-              enableExpandableRowHeader: false,
 
-              expandableRowTemplate: '<div ui-grid="row.entity.subGridOptions"></div>',
-              onRegisterApi: function (gridApi) {
-                  $scope.gridApi = gridApi;
-
-                  gridApi.pagination.on.paginationChanged($scope, function (newPage, pageSize) {
-                      $scope.model.pageNumber = newPage;
-                      $scope.model.pageSize = pageSize;
-                      resolvePage();
-                  });
-
-                  gridApi.core.on.sortChanged($scope, function (grid, sortColumns) {
-                      if (sortColumns.length === 0) {
-                          $scope.model.sort = null;
-                      } else {
-                          $scope.model.sort = [];
-                          for (var i = 0; i < sortColumns.length; i++) {
-                              $scope.model.sort.push({column: sortColumns[i].name, dir: sortColumns[i].sort.direction});
-                          }
-                      }
-                      resolvePage();
-                  });
-
-                  gridApi.core.on.columnVisibilityChanged( $scope, function( changedColumn ){
-                    $scope.columnChanged = { name: changedColumn.colDef.name, visible: changedColumn.colDef.visible };
-                  });
-
-                  gridApi.expandable.on.rowExpandedStateChanged($scope, function (row) {
-                      if (row.isExpanded) {
-                          paxService.getRuleHits(row.entity.id).then(function (data) {
-                              row.entity.subGridOptions.data = data;
-                          });
-                      }
+    $scope.passengerGrid = {
+      paginationPageSizes: [10, 25, 50],
+      paginationPageSize: 25,
+      paginationCurrentPage: $scope.model.pageNumber,
+      useExternalPagination: false,
+      useExternalSorting: false,
+      useExternalFiltering: false,
+      enableHorizontalScrollbar: 0,
+      enableVerticalScrollbar: 1,
+      enableFiltering: true,
+      enableColumnMenus: false,
+      multiSelect: false,
+      enableGridMenu: true,
+      enableExpandableRowHeader: false,
+      expandableRowTemplate: '<div ui-grid="row.entity.subGridOptions"></div>',
+      onRegisterApi: function (gridApi) {
+          $scope.gridApi = gridApi;
+          gridApi.expandable.on.rowExpandedStateChanged($scope, function (row) {
+              if (row.isExpanded) {
+                  paxService.getRuleHits(row.entity.id).then(function (data) {
+                      row.entity.subGridOptions.data = data;
                   });
               }
-          };
- 
+          });
+      }
+  };
+
     //Front-end pagination configuration object for gridUi
     //Should only be active on stateName === 'queryPassengers'
     $scope.passengerQueryGrid = {

--- a/gtas-parent/gtas-webapp/src/main/webapp/pax/pax.table.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/pax/pax.table.html
@@ -53,9 +53,9 @@
      ui-grid-move-columns
 		 ui-grid-auto-resize
 		 ui-grid-resize-columns
-     class="grid"></div>
+     class="grid" style="height: calc(100vh - 200px) !important;"></div>
 <h3 data-ng-if="stateName === 'queryPassengers'"class="block-label upper-cnt">Query Results: Passengers</h3>
-<h3 ng-if="queryLimitReached" class="block-label upper-cnt">Maximum result reached, data may be truncated</h3>
+<h5 ng-if="queryLimitReached" class="block-label upper-cnt">Maximum result reached, data may be truncated</h5>
 <div ng-if="stateName === 'queryPassengers'"
      id="grid1" ui-grid="passengerQueryGrid"
      ui-grid-pagination
@@ -64,4 +64,4 @@
      ui-grid-move-columns
 		 ui-grid-auto-resize
 		 ui-grid-resize-columns
-     class="grid"></div>
+     class="grid" style="height: calc(100vh - 220px) !important;"></div>


### PR DESCRIPTION
Resolves #1366, #1362
Removed unused onRegisterApi event handlers that were causing errors, reset the flightpax and querypax grids to scale using viewport height, fixed a null reference to a deleted element when clicking subgrid columns on flightpax and querypax.