### PR TITLE
Translation 1435

### DIFF
--- a/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_en.properties
+++ b/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_en.properties
@@ -305,6 +305,7 @@ rule.title=Title
 rule.conditions=Conditions
 
 qry.flightstitle=Query Results: Flights
+qry.maximumresults=Maximum result reached, data may be truncated
 btn.close=Close
 dashboard.title=Dashboard
 login.userid=Username

--- a/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_es.properties
+++ b/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_es.properties
@@ -285,6 +285,8 @@ hit.type=Type^
 hit.hittype=Hit Type^
 
 qry.flights=Vuelos de Consulta
+qry.flightstitle=Query Results: Flights^
+qry.maximumresults=Maximum result reached, data may be truncated^
 btn.close=Cerca
 dashboard.title=Tablero
 login.userid=Nombre de Usuario

--- a/gtas-parent/gtas-webapp/src/main/webapp/flights/query-flights.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/flights/query-flights.html
@@ -1,5 +1,5 @@
-<h3 class="block-label upper-cnt">Query Results: Flights</h3>
-<h3 ng-if="queryLimitReached" class="block-label upper-cnt">Maximum result reached, data may be truncated</h3>
+<h3 class="block-label upper-cnt">{{'qry.flightstitle' | translate}}</h3>
+<h3 ng-if="queryLimitReached" class="block-label upper-cnt">{{'qry.maximunresults' | translate}}</h3>
 <div ng-if="stateName != 'queryFlights'"
         ui-grid="flightsGrid"
         ui-grid-pagination

--- a/gtas-parent/gtas-webapp/src/main/webapp/flights/query-flights.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/flights/query-flights.html
@@ -1,5 +1,5 @@
 <h3 class="block-label upper-cnt">{{'qry.flightstitle' | translate}}</h3>
-<h3 ng-if="queryLimitReached" class="block-label upper-cnt">{{'qry.maximunresults' | translate}}</h3>
+<h3 ng-if="queryLimitReached" class="block-label upper-cnt">{{'qry.maximumresults' | translate}}</h3>
 <div ng-if="stateName != 'queryFlights'"
         ui-grid="flightsGrid"
         ui-grid-pagination


### PR DESCRIPTION
Affects the title and query-limit notification header on the query flights page.

To test, build any query in query builder and click the search flights button
   ![image](https://user-images.githubusercontent.com/49160279/66070486-68697780-e51f-11e9-9ecb-83f9e32c1387.png)

Then verify that the title banner on the flights page shows the translated text (see #1431 for instructions). To force the query-limit banner, you can cheat and update the flag in the code in flightscontroller.js. Set the value for `$scope.queryLimitReached`  to `true`  on line 106.
   ![image](https://user-images.githubusercontent.com/49160279/66070936-3ad0fe00-e520-11e9-8fe0-80d5f4c90c80.png)
