### PR TITLE
Move agency name to application.properties configuration, related to

### DIFF
--- a/gtas-parent/gtas-commons/src/main/resources/default.application.properties
+++ b/gtas-parent/gtas-commons/src/main/resources/default.application.properties
@@ -88,7 +88,9 @@ cleanup.initialDelay.in.milliseconds=2000
 datamanagement.fixedDelay.in.milliseconds=180
 datamanagement.initialDelay.in.milliseconds=20
 
-#########
+## Agency name displayed on the front end top header
+## It should be less than 50 characters long to fit in the layout of the page
+agency.name = ENTER AGENCY NAME HERE
 
 ##################### RuleRunner #####################
 enable.rule.runner=true

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/ConfigurationController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/ConfigurationController.java
@@ -8,15 +8,14 @@
 
 package gov.gtas.controller;
 
+import java.util.Base64;
+import java.util.Base64.Encoder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Base64;
-import java.util.Base64.Encoder;
 
 @RestController
 public class ConfigurationController {
@@ -41,7 +40,10 @@ public class ConfigurationController {
 	@Value("${neo4jpassword}")
 	String neo4jpassword;
 
-	@RequestMapping(method = RequestMethod.GET, value = "/api/config/dashboard", produces = "text/plain")
+	@Value("${agency.name}")
+	String agencyName;
+
+	@GetMapping(value = "/api/config/dashboard", produces = "text/plain")
 	public String getDashboard() {
 		String landingPage;
 		if (defaultLandingPage == null) {
@@ -53,22 +55,22 @@ public class ConfigurationController {
 		return landingPage;
 	}
 
-	@RequestMapping(method = RequestMethod.GET, value = "/api/config/kibanaUrl", produces = "text/plain")
+	@GetMapping(value = "/api/config/kibanaUrl", produces = "text/plain")
 	public String getDashboardUrl() {
 		return kibanaUrl;
 	}
 
-	@RequestMapping(method = RequestMethod.GET, value = "/api/config/neo4j", produces = "text/plain")
+	@GetMapping(value = "/api/config/neo4j", produces = "text/plain")
 	public String getNeo4J() {
 		return neo4jUrl;
 	}
 
-	@RequestMapping(method = RequestMethod.GET, value = "/api/config/cypherUrl", produces = "text/plain")
+	@GetMapping(value = "/api/config/cypherUrl", produces = "text/plain")
 	public String getCypherUrl() {
 		return cypherUrl;
 	}
 
-	@RequestMapping(method = RequestMethod.GET, value = "/api/config/cypherAuth", produces = "text/plain")
+	@GetMapping(value = "/api/config/cypherAuth", produces = "text/plain")
 	public String getCypherAuth() {
 		Encoder enc = Base64.getEncoder();
 		String authString = neo4jusername + ":" + neo4jpassword;
@@ -77,4 +79,8 @@ public class ConfigurationController {
 		return "Basic " + authEncoded;
 	}
 
+	@GetMapping(value = "/api/config/agencyName", produces = "text/plain")
+	public String getAgencyName() {
+		return agencyName;
+	}
 }

--- a/gtas-parent/gtas-webapp/src/main/webapp/app.js
+++ b/gtas-parent/gtas-webapp/src/main/webapp/app.js
@@ -685,6 +685,7 @@ var app;
             $scope.errorList = [];
             $scope.hitCount = 0;
             $scope.neo4jUrl = "http://localhost:7474/browser/";
+            $scope.agencyName = '';
             var originatorEv;
 
             this.openMenu = function($mdOpenMenu, ev) {
@@ -729,6 +730,14 @@ var app;
                     return $scope.hitCount;
             };
 
+            configService.agencyName().then(function(value) {
+                $scope.agencyName = value.data;
+             });
+            
+            $scope.getAgencyName = function() {
+            	return $scope.agencyName;
+            };
+            
             configService.neo4j().then(function(value) {
                $scope.neo4jUrl = value.data;
             });

--- a/gtas-parent/gtas-webapp/src/main/webapp/common/services.js
+++ b/gtas-parent/gtas-webapp/src/main/webapp/common/services.js
@@ -1680,6 +1680,15 @@
         });
         return response.then(handleSuccess, handleError);
       }
+        
+       function agencyName() {
+        	var dfd = $q.defer();
+            dfd.resolve($http({
+              method: 'get',
+              url: CONFIG_URL + "/agencyName"
+          }));
+          return dfd.promise;
+        }
 
       function handleError(response) {
         return $q.reject(response.data.message);
@@ -1694,7 +1703,8 @@
               neo4j: neo4j,
               kibanaUrl: kibanaUrl,
               cypherUrl: cypherUrl,
-              cypherAuth: cypherAuth
+              cypherAuth: cypherAuth,
+              agencyName: agencyName
           });
         });
   }());

--- a/gtas-parent/gtas-webapp/src/main/webapp/main.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/main.html
@@ -42,7 +42,7 @@
       <div class="navbar-header">
         <a class="navbar-brand" ng-href="#/{{homePage}}">
           <div class="gtas-brand"></div>
-          <div class="dhs-brand"></div>
+          <div class="gtas-brand-sub">{{getAgencyName()}}</div>
         </a>
         <button data-target="#navbar-user-info" data-toggle="collapse" type="button" class="navbar-toggle">
 		    <span class="sr-only">Toggle Global Navigation</span>

--- a/gtas-parent/gtas-webapp/src/main/webapp/resources/css/main.css
+++ b/gtas-parent/gtas-webapp/src/main/webapp/resources/css/main.css
@@ -37,6 +37,9 @@ body{
 .gtas-brand:before {
 	content: 'Global Travel Assessment System'
 }
+.gtas-brand-sub {
+	font-size: 13px;
+}
 @media (max-width:550px) {
     .gtas-brand:before {
         content: 'GTAS'


### PR DESCRIPTION
Related to #749

- update default.application.properties, add default configuration for
  agency.name = ENTER AGENCY NAME HERE

- update main.css/html to remove cbp-theme classes and bind dynamic
  text to replace the agency name on the front end.

- update services.js/ConfigurationController to  read the
  agency name property from application.properties.

  replace RequestMapping annotations with GetMapping while
  I was there.