### PR TITLE
Checkstyle implementation

### DIFF
--- a/gtas-parent/checkstyle.xml
+++ b/gtas-parent/checkstyle.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="AvoidStarImport">
+            <property name="severity" value="WARNING" />
+        </module>
+    </module>
+</module>

--- a/gtas-parent/pom.xml
+++ b/gtas-parent/pom.xml
@@ -277,6 +277,21 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <configLocation>checkstyle.xml</configLocation>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>


### PR DESCRIPTION
Checkstyle is a powerful code linting tool that, when enabled, can force local builds to fail when run with code that doesn't meet the expected criteria. 

For example when `severity` is switched from `WARNING` to `ERROR` in our current project, the build fails with the following error:

`src/main/java/gov/gtas/vo/passenger/BagSummaryVo.java:[6] (imports) AvoidStarImport: Using the '.*' form of import should be avoided - java.util.*.`

Checkstyle is flexible enough to allow custom rules to be configured.

Let me know if you all have any thoughts and/or suggestions