### PR TITLE
fixed the address state translation code, renamed the Baggage Pax Nam…

### DIFF
--- a/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_en.properties
+++ b/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_en.properties
@@ -198,6 +198,7 @@ flight.departurearrival=Departure / Arrival
 flight.passengers=Passengers
 flight.flights=Flights
 
+pass.passenger=Passenger
 pass.firstname=First Name
 pass.lastname=Last Name
 pass.middlename=Middle Name

--- a/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_es.properties
+++ b/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_es.properties
@@ -265,7 +265,7 @@ pnr.transDate=Transmission Date^
 add.addresses=Direcciones
 add.street=Street^
 add.city=Ciudad
-add.state=Estado
+add.stateprovince=Estado
 add.country=País
 
 phone=Teléfono^

--- a/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_es.properties
+++ b/gtas-parent/gtas-webapp/src/main/webapp/WEB-INF/messages/messages_es.properties
@@ -191,6 +191,7 @@ flight.departurearrival=Departure / Arrival^
 flight.passengers=Pasajeros
 flight.flights=Vuelos
 
+pass.passenger=Pasajero
 pass.firstname=Primer Nombre
 pass.lastname=Apellido
 pass.middlename=Segundo Nombre

--- a/gtas-parent/gtas-webapp/src/main/webapp/pax/paxTabs.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/pax/paxTabs.html
@@ -527,7 +527,7 @@
                                                 <tr>
                                                     <th>{{'add.street' | translate}}</th>
                                                     <th>{{'add.city' | translate}}</th>
-                                                    <th>{{'add.state' | translate}}</th>
+                                                    <th>{{'add.stateprovince' | translate}}</th>
                                                     <th>{{'add.country' | translate}}</th>
                                                 </tr>
                                                 </thead>
@@ -723,7 +723,7 @@
                                                 <thead aria-hidden="true">
                                                 <tr>
                                                     <th class="txt-right">{{'flight.flightnum' | translate}}</th>
-                                                    <th class="txt-right">{{'pass.passengername' | translate}}</th>
+                                                    <th class="txt-right">{{'pass.passenger' | translate}}</th>
                                                     <th class="txt-right">{{'bag.bagcount' | translate}}</th>
                                                     <th class="txt-right">{{'bag.totalbagweight' | translate}}</th>
                                                     <th class="txt-right">{{'bag.bagdestination' | translate}}</th>


### PR DESCRIPTION
…e column

Fixed in the English and Spanish test language files.

The Total PNR Baggage grid column was called Pax Last Name, but returned the pax full name. Changed this column header to just read 'Passenger'.

Also fix the code mapping for the Address grid's State col so it reads "State/Province" to better suit international addresses.