### PR TITLE
Fixes for qbrb#1718

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/JPQLGenerator.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/JPQLGenerator.java
@@ -319,6 +319,51 @@ public class JPQLGenerator {
 
 				}
 
+			} else if (entityEnum.toString().equalsIgnoreCase(Constants.EMAIL) ||
+					entityEnum.toString().equalsIgnoreCase(Constants.CREDITCARD) ||
+					entityEnum.toString().equalsIgnoreCase(Constants.DOCUMENT)) {
+
+				/* Due to a lack of direct connection between passenger and email/creditcard/etc...
+				 * IN/NOT_IN (and equals/not equals) behaviour does not work as intended through HQL, particularly because the order in
+				 * which the HQL separates the groupings goes from smallest -> largest, which allows for bad data
+				 * Example: A PNR 1, has 2 emails with domains: Gmail (2), and Hotmal (3). If Not In Gmail is used
+				 * 1 -> 2 would be false, but 1 -> 3 is true. This returns pnr 1 when it DOES contain gmail (which
+				 * in turn returns a passenger erroneously)
+				 * */
+
+				if (OperatorEnum.NOT_IN.toString().equalsIgnoreCase(operator)
+						|| OperatorEnum.NOT_EQUAL.toString().equalsIgnoreCase(operator)
+							) {
+					positionalParameter.increment();
+					//The inner join being made here swaps the value of the in or not in operator value
+					//in order to produce valid results, as we take the intersection of the haves vs have-nots
+					String whereClauseBridgeEntity;
+					String whereClauseBridgeEntityAlias;
+					// not in produces equivalent problems for not equal
+
+					//Different where clauses for document vs email/credit card
+					if(entityEnum.toString().equalsIgnoreCase((Constants.DOCUMENT))) {
+						whereClauseBridgeEntityAlias = "p";
+						whereClauseBridgeEntity = "Passenger";
+					} else {
+						whereClauseBridgeEntityAlias = "pnr";
+						whereClauseBridgeEntity = "Pnr";
+					}
+					//Construct special inner select statement in where clause with conditions
+					where.append(entityEnum.getAlias() + "." + field + " ");
+					where.append("not in" + (" (?") + positionalParameter + ") ");
+					where.append(Constants.AND + " " + whereClauseBridgeEntityAlias + ".id not in (");
+					where.append(Constants.SELECT + " " + whereClauseBridgeEntityAlias +".id from " + whereClauseBridgeEntity + " " + whereClauseBridgeEntityAlias);
+					where.append(Constants.LEFT_JOIN + whereClauseBridgeEntityAlias + entityEnum.getEntityReference() + " " + entityEnum.getAlias() + " ");
+					where.append(Constants.WHERE + " " + entityEnum.getAlias() + "." + field + " " + "in" + " (?" + positionalParameter + "))");
+
+				} else {
+					//default where
+					positionalParameter.increment();
+					where.append(entityEnum.getAlias()).append(".").append(field).append(" ")
+							.append(opEnum.getOperator()).append(" ?").append(positionalParameter);
+				}
+
 			} else {
 				// These four operators don't have any value ex. where firstname IS NULL
 				if (OperatorEnum.IS_EMPTY.toString().equalsIgnoreCase(operator)

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/repository/QueryBuilderRepositoryImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/repository/QueryBuilderRepositoryImpl.java
@@ -28,10 +28,7 @@ import gov.gtas.querybuilder.vo.PassengerQueryVo;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -450,6 +447,15 @@ public class QueryBuilderRepositoryImpl implements QueryBuilderRepository {
 							for (String val : values) {
 								vals.add(dtFormat.parse(val));
 							}
+						}
+						query.setParameter(positionalParameter.intValue(), vals);
+					} else if (entityEnum.toString().equalsIgnoreCase(EntityEnum.EMAIL.toString()) ||
+								entityEnum.toString().equalsIgnoreCase(EntityEnum.DOCUMENT.toString()) ||
+								entityEnum.toString().equalsIgnoreCase(EntityEnum.CREDIT_CARD.toString())) {
+						List<String> vals = new ArrayList<>();
+						if (values != null) {
+							for (String val : values)
+								Collections.addAll(vals, val.split(","));
 						}
 						query.setParameter(positionalParameter.intValue(), vals);
 					} else {

--- a/gtas-parent/gtas-commons/src/test/java/gov/gtas/querybuilder/JPQLGeneratorTest.java
+++ b/gtas-parent/gtas-commons/src/test/java/gov/gtas/querybuilder/JPQLGeneratorTest.java
@@ -5,6 +5,10 @@
  */
 package gov.gtas.querybuilder;
 
+import gov.gtas.model.udr.json.QueryEntity;
+import gov.gtas.model.udr.json.QueryObject;
+import gov.gtas.model.udr.json.QueryTerm;
+import gov.gtas.querybuilder.model.QueryRequest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +17,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import gov.gtas.enumtype.EntityEnum;
 import gov.gtas.querybuilder.exceptions.InvalidQueryRepositoryException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JPQLGeneratorTest {
@@ -91,6 +98,206 @@ public class JPQLGeneratorTest {
 		String joinCondition = JPQLGenerator.getJoinCondition(queryTypePassenger, queryTypePassenger);
 		Assert.assertEquals(" join f.passengers p", joinCondition);
 
+	}
+
+	@Test
+	public void testNotInWhereClauseForEmail() throws InvalidQueryRepositoryException {
+		String expectedQuery = "select distinct p.id, p, p.flight from Passenger p left join" +
+				" p.flight f  left join p.pnrs pnr left join pnr.emails e where (e.domain not in (?1) and " +
+				"pnr.id not in (select pnr.id from Pnr pnr left join pnr.emails e where e.domain in (?1)))";
+
+		QueryObject mockQueryObject  = new QueryObject();
+		QueryTerm mockQueryTerm = new QueryTerm();
+
+		mockQueryTerm.setUuid(null);
+		mockQueryTerm.setType("string");
+		mockQueryTerm.setEntity("Email");
+		mockQueryTerm.setOperator("NOT_IN");
+		mockQueryTerm.setValue(new String[]{"HOTMAIL.COM"});
+		mockQueryTerm.setField("domain");
+
+		List<QueryEntity> mockQTList = new ArrayList<>();
+		mockQTList.add(mockQueryTerm);
+
+		mockQueryObject.setCondition("AND");
+		mockQueryObject.setRules(mockQTList);
+
+		String query = JPQLGenerator.generateQuery(mockQueryObject, EntityEnum.PASSENGER);
+		Assert.assertEquals(expectedQuery, query);
+	}
+
+	@Test
+	public void testInWhereClauseForEmail() throws InvalidQueryRepositoryException {
+		String expectedQuery = "select distinct p.id, p, p.flight from Passenger p left join p.flight f  " +
+				"left join p.pnrs pnr left join pnr.emails e where (e.domain in ?1)";
+
+		QueryObject mockQueryObject  = new QueryObject();
+		QueryTerm mockQueryTerm = new QueryTerm();
+
+		mockQueryTerm.setUuid(null);
+		mockQueryTerm.setType("string");
+		mockQueryTerm.setEntity("Email");
+		mockQueryTerm.setOperator("IN");
+		mockQueryTerm.setValue(new String[]{"HOTMAIL.COM"});
+		mockQueryTerm.setField("domain");
+
+		List<QueryEntity> mockQTList = new ArrayList<>();
+		mockQTList.add(mockQueryTerm);
+
+		mockQueryObject.setCondition("AND");
+		mockQueryObject.setRules(mockQTList);
+
+		String query = JPQLGenerator.generateQuery(mockQueryObject, EntityEnum.PASSENGER);
+		Assert.assertEquals(expectedQuery, query);
+	}
+
+	@Test
+	public void testNotEqualsWhereClauseForEmail() throws InvalidQueryRepositoryException {
+		String expectedQuery = "select distinct p.id, p, p.flight from Passenger p left join" +
+				" p.flight f  left join p.pnrs pnr left join pnr.emails e where (e.domain not in (?1) and " +
+				"pnr.id not in (select pnr.id from Pnr pnr left join pnr.emails e where e.domain in (?1)))";
+
+		QueryObject mockQueryObject  = new QueryObject();
+		QueryTerm mockQueryTerm = new QueryTerm();
+
+		mockQueryTerm.setUuid(null);
+		mockQueryTerm.setType("string");
+		mockQueryTerm.setEntity("Email");
+		mockQueryTerm.setOperator("NOT_EQUAL");
+		mockQueryTerm.setValue(new String[]{"HOTMAIL.COM"});
+		mockQueryTerm.setField("domain");
+
+		List<QueryEntity> mockQTList = new ArrayList<>();
+		mockQTList.add(mockQueryTerm);
+
+		mockQueryObject.setCondition("AND");
+		mockQueryObject.setRules(mockQTList);
+
+		String query = JPQLGenerator.generateQuery(mockQueryObject, EntityEnum.PASSENGER);
+		Assert.assertEquals(expectedQuery, query);
+	}
+
+	@Test
+	public void testEqualsWhereClauseForEmail() throws InvalidQueryRepositoryException {
+		String expectedQuery = "select distinct p.id, p, p.flight from Passenger p left join p.flight f" +
+				"  left join p.pnrs pnr left join pnr.emails e where (e.domain = ?1)";
+
+		QueryObject mockQueryObject  = new QueryObject();
+		QueryTerm mockQueryTerm = new QueryTerm();
+
+		mockQueryTerm.setUuid(null);
+		mockQueryTerm.setType("string");
+		mockQueryTerm.setEntity("Email");
+		mockQueryTerm.setOperator("EQUALS");
+		mockQueryTerm.setValue(new String[]{"HOTMAIL.COM"});
+		mockQueryTerm.setField("domain");
+
+		List<QueryEntity> mockQTList = new ArrayList<>();
+		mockQTList.add(mockQueryTerm);
+
+		mockQueryObject.setCondition("AND");
+		mockQueryObject.setRules(mockQTList);
+
+		String query = JPQLGenerator.generateQuery(mockQueryObject, EntityEnum.PASSENGER);
+		Assert.assertEquals(expectedQuery, query);
+	}
+
+	@Test
+	public void testNotInWhereClauseForDocument() throws InvalidQueryRepositoryException {
+		String expectedQuery = "select distinct p.id, p, p.flight from Passenger p left join p.flight f" +
+				"  join p.documents d where (d.type not in (?1) and p.id not in (select p.id from Passenger p left join p.documents d where d.type in (?1)))";
+
+		QueryObject mockQueryObject  = new QueryObject();
+		QueryTerm mockQueryTerm = new QueryTerm();
+
+		mockQueryTerm.setUuid(null);
+		mockQueryTerm.setType("string");
+		mockQueryTerm.setEntity("Document");
+		mockQueryTerm.setOperator("NOT_IN");
+		mockQueryTerm.setValue(new String[]{"V"});
+		mockQueryTerm.setField("type");
+
+		List<QueryEntity> mockQTList = new ArrayList<>();
+		mockQTList.add(mockQueryTerm);
+
+		mockQueryObject.setCondition("AND");
+		mockQueryObject.setRules(mockQTList);
+
+		String query = JPQLGenerator.generateQuery(mockQueryObject, EntityEnum.PASSENGER);
+		Assert.assertEquals(expectedQuery, query);
+	}
+
+	@Test
+	public void testInWhereClauseForDocument() throws InvalidQueryRepositoryException {
+		String expectedQuery = "select distinct p.id, p, p.flight from Passenger p left join p.flight f  join p.documents d where (d.type in ?1)";
+
+		QueryObject mockQueryObject  = new QueryObject();
+		QueryTerm mockQueryTerm = new QueryTerm();
+
+		mockQueryTerm.setUuid(null);
+		mockQueryTerm.setType("string");
+		mockQueryTerm.setEntity("Document");
+		mockQueryTerm.setOperator("IN");
+		mockQueryTerm.setValue(new String[]{"V"});
+		mockQueryTerm.setField("type");
+
+		List<QueryEntity> mockQTList = new ArrayList<>();
+		mockQTList.add(mockQueryTerm);
+
+		mockQueryObject.setCondition("AND");
+		mockQueryObject.setRules(mockQTList);
+
+		String query = JPQLGenerator.generateQuery(mockQueryObject, EntityEnum.PASSENGER);
+		Assert.assertEquals(expectedQuery, query);
+	}
+
+	@Test
+	public void testNotEqualsWhereClauseForDocument() throws InvalidQueryRepositoryException {
+		String expectedQuery = "select distinct p.id, p, p.flight from Passenger p left join p.flight f  " +
+				"join p.documents d where (d.type not in (?1) and p.id not in (select p.id from Passenger p left join p.documents d where d.type in (?1)))";
+
+		QueryObject mockQueryObject  = new QueryObject();
+		QueryTerm mockQueryTerm = new QueryTerm();
+
+		mockQueryTerm.setUuid(null);
+		mockQueryTerm.setType("string");
+		mockQueryTerm.setEntity("Document");
+		mockQueryTerm.setOperator("NOT_EQUAL");
+		mockQueryTerm.setValue(new String[]{"V"});
+		mockQueryTerm.setField("type");
+
+		List<QueryEntity> mockQTList = new ArrayList<>();
+		mockQTList.add(mockQueryTerm);
+
+		mockQueryObject.setCondition("AND");
+		mockQueryObject.setRules(mockQTList);
+
+		String query = JPQLGenerator.generateQuery(mockQueryObject, EntityEnum.PASSENGER);
+		Assert.assertEquals(expectedQuery, query);
+	}
+
+	@Test
+	public void testEqualsWhereClauseForDocument() throws InvalidQueryRepositoryException {
+		String expectedQuery = "select distinct p.id, p, p.flight from Passenger p left join p.flight f  join p.documents d where (d.type = ?1)";
+
+		QueryObject mockQueryObject  = new QueryObject();
+		QueryTerm mockQueryTerm = new QueryTerm();
+
+		mockQueryTerm.setUuid(null);
+		mockQueryTerm.setType("string");
+		mockQueryTerm.setEntity("Document");
+		mockQueryTerm.setOperator("EQUAL");
+		mockQueryTerm.setValue(new String[]{"V"});
+		mockQueryTerm.setField("type");
+
+		List<QueryEntity> mockQTList = new ArrayList<>();
+		mockQTList.add(mockQueryTerm);
+
+		mockQueryObject.setCondition("AND");
+		mockQueryObject.setRules(mockQTList);
+
+		String query = JPQLGenerator.generateQuery(mockQueryObject, EntityEnum.PASSENGER);
+		Assert.assertEquals(expectedQuery, query);
 	}
 
 }


### PR DESCRIPTION
This fixes current anomalous behaviour with In/Not in and directly related Equals/Not Equals with our query builder as it pertains to Email, Document, and Creditcard

The underlying issue is a combination of connecting certain elements (Email, Creditcard) through PNR rather than passenger, and that in any X to MANY relationship with our current query builder implementation the base line where clause construction is insufficient for not in and not equals specifically.

Going forward, IN and EQUALS will both function as soft inclusive, where NOT IN and NOT EQUALS will function as hard exclusive with their terms. This is not logically equivalent, but given our data structure as it is and how a user would feel about using it, this has been surmised as the correct way.

There is a lingering issue that exceeded the scope of this ticket in that selectize multi-variable selections seemed to concatenate values with a comma. This was fixed for the entities mentioned above, but an exhaustive search was not done for all potential string multi-values.