### PR TITLE
Removing flight pax

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/email/HitEmailNotificationService.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/email/HitEmailNotificationService.java
@@ -116,7 +116,7 @@ public class HitEmailNotificationService {
 
     public EmailDTO generateManualNotificationEmailDTO(String[] to, String note, Long paxId, String userID) throws IOException, TemplateException {
         User sender = userRepository.userAndGroups(userID).orElseThrow(RuntimeException::new);
-        Passenger passenger = passengerService.findByIdWithFlightPaxAndDocumentsAndHitDetails(paxId);
+        Passenger passenger = passengerService.findByIdWithFlightAndDocumentsAndHitDetails(paxId);
         EmailDTO emailDTO = new EmailDTO();
 
         HitEmailDTO hitEmailDTO = generateHitEmailDTO(passenger, note, sender);

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/Address.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/Address.java
@@ -50,17 +50,6 @@ public class Address extends BaseEntityAudit {
 	@ManyToMany(mappedBy = "addresses", targetEntity = Pnr.class)
 	private Set<Pnr> pnrs = new HashSet<>();
 
-	@OneToMany(cascade = CascadeType.ALL, mappedBy = "installationAddress", orphanRemoval = true)
-	private Set<FlightPax> flightPaxList = new HashSet<>();
-
-	public Set<FlightPax> getFlightPaxList() {
-		return flightPaxList;
-	}
-
-	public void setFlightPaxList(Set<FlightPax> flightPaxList) {
-		this.flightPaxList = flightPaxList;
-	}
-
 	public String getLine1() {
 		return line1;
 	}

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/FlightPax.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/FlightPax.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import javax.persistence.*;
 
+@Deprecated
 @Entity
 @Table(name = "flight_pax", indexes = @Index(columnList = "ref_number", name = "flight_pax_ref_number_index"))
 public class FlightPax implements Serializable {
@@ -31,10 +32,6 @@ public class FlightPax implements Serializable {
 
 	@Column(name = "residence_country")
 	private String residenceCountry;
-
-	@ManyToOne
-	@JoinColumn(name = "install_address_id", nullable = true, referencedColumnName = "id")
-	private Address installationAddress;
 
 	@Column(name = "embarkation")
 	private String embarkation;
@@ -148,14 +145,6 @@ public class FlightPax implements Serializable {
 
 	public void setResidenceCountry(String residenceCountry) {
 		this.residenceCountry = residenceCountry;
-	}
-
-	public Address getInstallationAddress() {
-		return installationAddress;
-	}
-
-	public void setInstallationAddress(Address installationAddress) {
-		this.installationAddress = installationAddress;
 	}
 
 	public String getEmbarkation() {

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/ApisMessageRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/ApisMessageRepository.java
@@ -25,12 +25,12 @@ public interface ApisMessageRepository extends MessageRepository<ApisMessage> {
 	List<String> findApisRefByFlightIdandPassengerId(@Param("flightId") Long flightId,
 			@Param("passengerId") Long passengerId);
 
-	@Query("SELECT fp FROM ApisMessage apis join apis.flightPaxList fp where fp.reservationReferenceNumber = :refNumber and fp.flightId = :flightId")
-	Set<FlightPax> findFlightPaxByApisRef(@Param("refNumber") String refNumber, @Param("flightId") long flightId);
+	@Query("SELECT p FROM Passenger p join p.passengerTripDetails ptd where p.flight.id = :flightId  and ptd.reservationReferenceNumber = :refNumber")
+	Set<Passenger> findPassengerByApisRef(@Param("refNumber") String refNumber, @Param("flightId") long flightId);
 
-	@Query("SELECT fp FROM ApisMessage apis join apis.flightPaxList fp where fp.passenger.id = :passengerId and fp.flight.id = :flightId")
-	List<FlightPax> findFlightPaxByFlightIdandPassengerId(@Param("flightId") Long flightId,
-			@Param("passengerId") Long passengerId);
+	@Query("SELECT p FROM Passenger p left join fetch p.bags pbags left join fetch pbags.bagMeasurements where p.id = :passengerId and p.flight.id = :flightId")
+	Passenger findPaxByFlightIdandPassengerId(@Param("flightId") Long flightId,
+											  @Param("passengerId") Long passengerId);
 
 	@Query("SELECT apis FROM ApisMessage apis WHERE apis.createDate >= current_date() - 1")
 	public List<Message> getAPIsByDates();

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/BookingDetailRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/BookingDetailRepository.java
@@ -20,18 +20,20 @@ import java.util.List;
 public interface BookingDetailRepository extends CrudRepository<BookingDetail, Long> {
 
 	@Query("SELECT pax FROM Passenger pax " + "left join fetch pax.passengerDetails  "
-			+ "left join fetch pax.bookingDetails " + "left join fetch pax.flightPaxList pfpl "
-			+ "left join fetch pax.passengerTripDetails " + "left join fetch pfpl.flight "
-			+ "left join fetch pfpl.passenger  WHERE pax.id IN ("
+			+ "left join fetch pax.bookingDetails "
+			+ "left join fetch pax.passengerTripDetails "
+			+ "left join fetch pax.flight "
+			+ "WHERE pax.id IN ("
 			+ "SELECT pxtag.pax_id FROM PassengerIDTag pxtag WHERE pxtag.idTag IN (SELECT p.idTag FROM PassengerIDTag p WHERE p.pax_id = (:pax_id) ))")
 	List<Passenger> getBookingDetailsByPassengerIdTag(@Param("pax_id") Long pax_id);
 
     @Query("SELECT pax FROM Passenger pax " + "left join fetch pax.passengerDetails  "
-            + "left join fetch pax.bookingDetails " + "left join fetch pax.flightPaxList pfpl "
-            + "left join fetch pax.passengerTripDetails " + "left join fetch pfpl.flight "
-            + "left join fetch pfpl.passenger  WHERE pax.id IN ("
+			+ "left join fetch pax.bookingDetails "
+			+ "left join fetch pax.passengerTripDetails "
+			+ "left join fetch pax.flight "
+			+ "WHERE pax.id IN ("
             + "SELECT pxtag.pax_id FROM PassengerIDTag pxtag WHERE "
-            + "pxtag.tamrId IN (SELECT p.tamrId FROM PassengerIDTag p WHERE p.pax_id = (:pax_id)) "
+			+ "pxtag.tamrId IN (SELECT p.tamrId FROM PassengerIDTag p WHERE p.pax_id = (:pax_id)) "
             + "AND pxtag.tamrId IS NOT NULL)")
 	List<Passenger> getBookingDetailsByTamrId(@Param("pax_id") Long pax_id);
 	

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/CountryRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/CountryRepository.java
@@ -5,7 +5,6 @@
  */
 package gov.gtas.repository;
 
-import gov.gtas.model.FlightPax;
 import gov.gtas.model.lookup.Country;
 
 import java.util.List;

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/FlightPaxRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/FlightPaxRepository.java
@@ -10,11 +10,9 @@ import javax.transaction.Transactional;
 import java.util.Collection;
 import java.util.Set;
 
+@Deprecated
 public interface FlightPaxRepository extends CrudRepository<FlightPax, Long> {
 
-	default FlightPax findOne(Long flightPaxId) {
-		return findById(flightPaxId).orElse(null);
-	}
 
 	@Transactional
 	@Query("SELECT fps FROM FlightPax fps WHERE fps.passenger.id IN :pidList")

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/PassengerRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/PassengerRepository.java
@@ -33,14 +33,14 @@ public interface PassengerRepository extends JpaRepository<Passenger, Long>, Pas
 
 	@Query("SELECT p FROM Passenger p " + "left join fetch p.passengerTripDetails "
 			+ "left join fetch p.passengerDetails " + "left join fetch p.documents "
-			+ "left join fetch p.flightPaxList pfl " + "left join fetch pfl.flight " + "WHERE p.id = :id")
-	Passenger findByIdWithFlightPaxAndDocuments(@Param("id") Long id);
+			+ "left join fetch p.flight " + "WHERE p.id = :id")
+	Passenger findByIdWithFlightAndDocuments(@Param("id") Long id);
 	
 	@Query("SELECT p FROM Passenger p " + "left join fetch p.passengerTripDetails "
 			+ "left join fetch p.passengerDetails " + "left join fetch p.documents "
-			+ "left join fetch p.flightPaxList pfl " + "left join fetch pfl.flight " 
+			+ "left join fetch p.flight "
 			+ "left join fetch p.hitDetails " +  "WHERE p.id = :id")
-	Passenger findByIdWithFlightPaxAndDocumentsAndHitDetails(@Param("id") Long id);
+	Passenger findByIdWithFlightAndDocumentsAndHitDetails(@Param("id") Long id);
 
 	default Passenger findOne(Long passengerId) {
 		return findById(passengerId).orElse(null);
@@ -93,4 +93,5 @@ public interface PassengerRepository extends JpaRepository<Passenger, Long>, Pas
 
 	@Query("SELECT p from Passenger p where p.id in :paxIds")
     Set<Passenger> getPassengersForEmailDto(@Param("paxIds") Set<Long> paxIds);
+
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/ApisControllerService.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/ApisControllerService.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface ApisControllerService {
 
-	List<FlightPassengerVo> generateFlightPaxVoByApisRef(String ref, long flightId);
+	List<FlightPassengerVo> generateFlightPassengerList(String ref, long flightId);
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/ApisControllerServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/ApisControllerServiceImpl.java
@@ -1,10 +1,8 @@
 package gov.gtas.services;
 
-import gov.gtas.model.Address;
-import gov.gtas.model.FlightPax;
+import gov.gtas.model.Passenger;
 import gov.gtas.repository.ApisMessageRepository;
 import gov.gtas.services.search.FlightPassengerVo;
-import gov.gtas.vo.passenger.AddressVo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,35 +18,23 @@ public class ApisControllerServiceImpl implements ApisControllerService {
 	ApisMessageRepository apisMessageRepository;
 
 	@Transactional
-	public List<FlightPassengerVo> generateFlightPaxVoByApisRef(String ref, long flightId) {
-		Set<FlightPax> fpList = apisMessageRepository.findFlightPaxByApisRef(ref, flightId);
+	public List<FlightPassengerVo> generateFlightPassengerList(String ref, long flightId) {
+		Set<Passenger> fpList = apisMessageRepository.findPassengerByApisRef(ref, flightId);
 		List<FlightPassengerVo> flightPassengerVos = new ArrayList<>();
-		for (FlightPax fp : fpList) {
+		for (Passenger p : fpList) {
 			FlightPassengerVo fpVo = new FlightPassengerVo();
-			fpVo.setFirstName(fp.getPassenger().getPassengerDetails().getFirstName());
-			fpVo.setLastName(fp.getPassenger().getPassengerDetails().getLastName());
-			fpVo.setMiddleName(fp.getPassenger().getPassengerDetails().getMiddleName());
-			fpVo.setEmbarkation(fp.getEmbarkation());
-			fpVo.setDebarkation(fp.getDebarkation());
-			if (fp.getInstallationAddress() != null) {
-				AddressVo add = new AddressVo();
-				Address installAdd = fp.getInstallationAddress();
-				add.setLine1(installAdd.getLine1());
-				add.setLine2(installAdd.getLine2());
-				add.setLine3(installAdd.getLine3());
-				add.setCity(installAdd.getCity());
-				add.setCountry(installAdd.getCountry());
-				add.setPostalCode(installAdd.getPostalCode());
-				add.setState(installAdd.getState());
-				fpVo.setInstallationAddress(add);
-			}
-			fpVo.setPortOfFirstArrival(fp.getPortOfFirstArrival());
-			fpVo.setResidencyCountry(fp.getResidenceCountry());
-			fpVo.setPassengerType(fp.getTravelerType());
-			fpVo.setNationality(fp.getPassenger().getPassengerDetails().getNationality());
-			fpVo.setResRefNumber(fp.getReservationReferenceNumber());
-			fpVo.setFlightId(fp.getFlight().getId());
-			fpVo.setPassengerId(fp.getPassenger().getId());
+			fpVo.setFirstName(p.getPassengerDetails().getFirstName());
+			fpVo.setLastName(p.getPassengerDetails().getLastName());
+			fpVo.setMiddleName(p.getPassengerDetails().getMiddleName());
+			fpVo.setEmbarkation(p.getPassengerTripDetails().getEmbarkation());
+			fpVo.setDebarkation(p.getPassengerTripDetails().getDebarkation());
+			fpVo.setPortOfFirstArrival(p.getFlight().getDestination());
+			fpVo.setResidencyCountry(p.getPassengerDetails().getNationality());
+			fpVo.setPassengerType(p.getPassengerDetails().getPassengerType());
+			fpVo.setNationality(p.getPassengerDetails().getNationality());
+			fpVo.setResRefNumber(p.getPassengerTripDetails().getReservationReferenceNumber());
+			fpVo.setFlightId(p.getFlight().getId());
+			fpVo.setPassengerId(p.getId());
 			flightPassengerVos.add(fpVo);
 		}
 		return flightPassengerVos;

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/EventReportServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/EventReportServiceImpl.java
@@ -12,7 +12,6 @@ import javax.annotation.Resource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
 import gov.gtas.enumtype.HitSeverityEnum;
@@ -23,7 +22,6 @@ import gov.gtas.model.HitMaker;
 import gov.gtas.model.HitViewStatus;
 import gov.gtas.model.Passenger;
 import gov.gtas.model.Pnr;
-import gov.gtas.model.UserGroup;
 import gov.gtas.model.lookup.HitCategory;
 import gov.gtas.repository.ApisMessageRepository;
 import gov.gtas.services.dto.PassengerNoteSetDto;
@@ -31,7 +29,6 @@ import gov.gtas.services.dto.PaxDetailPdfDocRequest;
 import gov.gtas.services.dto.PaxDetailPdfDocResponse;
 import gov.gtas.util.PaxDetailVoUtil;
 import gov.gtas.vo.HitDetailVo;
-import gov.gtas.vo.NoteVo;
 import gov.gtas.vo.passenger.DocumentVo;
 import gov.gtas.vo.passenger.FlightVoForFlightHistory;
 import gov.gtas.vo.passenger.PassengerVo;
@@ -59,7 +56,7 @@ public class EventReportServiceImpl implements EventReportService {
 	public EventReportServiceImpl(FlightService flightService, PnrService pnrService,
 			PassengerService passengerService, HitDetailService hitDetailService,
 			EventReportPdfService<PaxDetailPdfDocRequest, PaxDetailPdfDocResponse> passengerEventReportService,
-			HitDetailService hitsDetailsService, PassengerNoteService passengerNoteService) {
+			PassengerNoteService passengerNoteService) {
 		this.flightService = flightService;
 		this.pnrService = pnrService;
 		this.passengerService = passengerService;
@@ -77,7 +74,7 @@ public class EventReportServiceImpl implements EventReportService {
 		PassengerVo passengerVo = new PassengerVo();
 		Flight flight = flightService.findById(flightId);
 
-		Passenger passenger = passengerService.findByIdWithFlightPaxAndDocuments(paxId);
+		Passenger passenger = passengerService.findByIdWithFlightAndDocuments(paxId);
 
 		if (passenger != null && flight != null) {
 			if (flight.getId().equals(flightId)) {

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/PassengerService.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/PassengerService.java
@@ -28,10 +28,10 @@ public interface PassengerService {
 	Passenger findById(Long id);
 
 	@PreAuthorize(PRIVILEGES_ADMIN_AND_VIEW_PASSENGER)
-	Passenger findByIdWithFlightPaxAndDocuments(Long paxId);
-	
+	Passenger findByIdWithFlightAndDocuments(Long paxId);
+
 	@PreAuthorize(PRIVILEGES_ADMIN_AND_VIEW_PASSENGER)
-	Passenger findByIdWithFlightPaxAndDocumentsAndHitDetails(Long paxId);
+	Passenger findByIdWithFlightAndDocumentsAndHitDetails(Long paxId);
 
 	/**
 	 * Gets the passengers by criteria.
@@ -54,7 +54,7 @@ public interface PassengerService {
 	@PreAuthorize(PRIVILEGES_ADMIN_AND_VIEW_PASSENGER)
 	List<Passenger> getBookingDetailHistoryByPaxID(Long pId);
 
-	Set<FlightPax> findFlightPaxFromPassengerIds(List<Long> passengerIdList);
+	Set<Passenger> findPassengerFromPassengerIds(List<Long> passengerIdList);
 
 	void setAllFlights(Set<Flight> flights, Long id);
 

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/PassengerServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/PassengerServiceImpl.java
@@ -61,9 +61,6 @@ public class PassengerServiceImpl implements PassengerService {
 	PassengerRepository passengerRepository;
 
 	@Autowired
-	FlightPaxRepository flightPaxRepository;
-
-	@Autowired
 	AppConfigurationService appConfigurationService;
 
 	@Value("${tamr.enabled}")
@@ -120,15 +117,15 @@ public class PassengerServiceImpl implements PassengerService {
 			}
 
 			// grab flight info
-			Flight flightPaxOn = passenger.getFlight();
-			vo.setFlightId(flightPaxOn.getId().toString());
-			vo.setFlightNumber(flightPaxOn.getFlightNumber());
-			vo.setFullFlightNumber(flightPaxOn.getFullFlightNumber());
-			vo.setCarrier(flightPaxOn.getCarrier());
-			vo.setFlightOrigin(flightPaxOn.getOrigin());
-			vo.setFlightDestination(flightPaxOn.getDestination());
-			vo.setEtd(flightPaxOn.getMutableFlightDetails().getEtd());
-			vo.setEta(flightPaxOn.getMutableFlightDetails().getEta());
+			Flight passengerFlight = passenger.getFlight();
+			vo.setFlightId(passengerFlight.getId().toString());
+			vo.setFlightNumber(passengerFlight.getFlightNumber());
+			vo.setFullFlightNumber(passengerFlight.getFullFlightNumber());
+			vo.setCarrier(passengerFlight.getCarrier());
+			vo.setFlightOrigin(passengerFlight.getOrigin());
+			vo.setFlightDestination(passengerFlight.getDestination());
+			vo.setEtd(passengerFlight.getMutableFlightDetails().getEtd());
+			vo.setEta(passengerFlight.getMutableFlightDetails().getEta());
 			rv.add(vo);
 			count++;
 		}
@@ -195,14 +192,14 @@ public class PassengerServiceImpl implements PassengerService {
 
 	@Override
 	@Transactional
-	public Passenger findByIdWithFlightPaxAndDocuments(Long paxId) {
-		return passengerRepository.findByIdWithFlightPaxAndDocuments(paxId);
+	public Passenger findByIdWithFlightAndDocuments(Long paxId) {
+		return passengerRepository.findByIdWithFlightAndDocuments(paxId);
 	}
 	
 	@Override
 	@Transactional
-	public Passenger findByIdWithFlightPaxAndDocumentsAndHitDetails(Long paxId) {
-		return passengerRepository.findByIdWithFlightPaxAndDocumentsAndHitDetails(paxId);
+	public Passenger findByIdWithFlightAndDocumentsAndHitDetails(Long paxId) {
+		return passengerRepository.findByIdWithFlightAndDocumentsAndHitDetails(paxId);
 	}
 
 	@Override
@@ -240,8 +237,8 @@ public class PassengerServiceImpl implements PassengerService {
 	}
 
 	@Override
-	public Set<FlightPax> findFlightPaxFromPassengerIds(List<Long> passengerIdList) {
-		return flightPaxRepository.findFlightFromPassIdList(passengerIdList);
+	public Set<Passenger> findPassengerFromPassengerIds(List<Long> passengerIdList) {
+		return new HashSet<>(passengerRepository.getPassengersById(passengerIdList));
 	}
 
 	@Override

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/search/ElasticHelper.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/search/ElasticHelper.java
@@ -60,7 +60,6 @@ import gov.gtas.vo.passenger.LinkPassengerVo;
 public class ElasticHelper {
 	private static final Logger logger = LoggerFactory.getLogger(ElasticHelper.class);
 	private static final String INDEX_NAME = "flightpax";
-	private static final String FLIGHTPAX_TYPE = "doc";
 	private static final String CREDENTIALS = "xpack.security.user";
 	private static final String NODE_NAME = "node.name";
 	private static final String CLUSTER_NAME = "cluster.name";

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/util/PaxDetailVoUtil.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/util/PaxDetailVoUtil.java
@@ -2,13 +2,7 @@ package gov.gtas.util;
 
 import static java.util.stream.Collectors.toList;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -26,7 +20,6 @@ import gov.gtas.model.Document;
 import gov.gtas.model.Email;
 import gov.gtas.model.Flight;
 import gov.gtas.model.FlightLeg;
-import gov.gtas.model.FlightPax;
 import gov.gtas.model.FrequentFlyer;
 import gov.gtas.model.Passenger;
 import gov.gtas.model.Phone;
@@ -50,15 +43,11 @@ public class PaxDetailVoUtil {
 
 	public static List<FlightVoForFlightHistory> copyBookingDetailFlightModelToVo(
 			List<Passenger> allPassengersRelatingToSingleIdTag) {
-
 		List<FlightVoForFlightHistory> flightsAndBookingDetailsRelatingToSamePaxIdTag = new ArrayList<>();
-
 		try {
-
-			List<FlightPax> flightPassengersList = getFlightPaxes(allPassengersRelatingToSingleIdTag);
-
+			Set<Passenger> flightPassengersList = new HashSet<>(allPassengersRelatingToSingleIdTag);
 			Set<Pair<Passenger, Flight>> associatedPaxFlights = flightPassengersList.stream()
-					.map(flightPax -> new ImmutablePair<>(flightPax.getPassenger(), flightPax.getFlight()))
+					.map(p -> new ImmutablePair<>(p, p.getFlight()))
 					.collect(Collectors.toSet());
 
 			List<FlightVoForFlightHistory> flightHistory = associatedPaxFlights.stream().map(passengerFlightPair -> {
@@ -89,23 +78,6 @@ public class PaxDetailVoUtil {
 		}
 
 		return flightsAndBookingDetailsRelatingToSamePaxIdTag;
-	}
-
-	public static List<FlightPax> getFlightPaxes(List<Passenger> allPassengersRelatingToSingleIdTag) {
-
-		List<FlightPax> flightPaxes = allPassengersRelatingToSingleIdTag.stream()
-				.flatMap(p -> p.getFlightPaxList().stream()).collect(toList());
-
-		List<FlightPax> filteredFlightPax = new ArrayList<>();
-		Map<Pair<Passenger, Flight>, Boolean> flightPaxRecorded = new HashMap<>();
-		for (FlightPax fp : flightPaxes) {
-			Pair<Passenger, Flight> flightPaxCombination = new ImmutablePair<>(fp.getPassenger(), fp.getFlight());
-			if (!flightPaxRecorded.containsKey(flightPaxCombination)) {
-				flightPaxRecorded.put(flightPaxCombination, true);
-				filteredFlightPax.add(fp);
-			}
-		}
-		return filteredFlightPax;
 	}
 
 	public static void populateFlightVoWithBookingDetail(BookingDetail source, FlightVo target) {

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/vo/passenger/ApisMessageVo.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/vo/passenger/ApisMessageVo.java
@@ -79,14 +79,6 @@ public class ApisMessageVo extends MessageVo {
 		bags.add(b);
 	}
 
-	public Set<FlightPassengerVo> getFlightpaxs() {
-		return flightpaxs;
-	}
-
-	public void setFlightpaxs(Set<FlightPassengerVo> flightpaxs) {
-		this.flightpaxs = flightpaxs;
-	}
-
 	public void addFlightpax(FlightPassengerVo flightpax) {
 		this.flightpaxs.add(flightpax);
 	}

--- a/gtas-parent/gtas-commons/src/test/java/gov/gtas/services/EventReportServiceTest.java
+++ b/gtas-parent/gtas-commons/src/test/java/gov/gtas/services/EventReportServiceTest.java
@@ -141,10 +141,13 @@ public class EventReportServiceTest {
 		try {
 			eventReportService.setFlightHistory(paxDetailPdfDocRequest, 1L);
 			List<FlightVoForFlightHistory> flightHistory = paxDetailPdfDocRequest.getFlightHistoryVoList();
-			Assert.assertNotNull(flightHistory);
-			FlightVoForFlightHistory flightVoForFlightHistory = flightHistory.get(0);
-			Assert.assertEquals(String.valueOf("22"), flightVoForFlightHistory.getFlightId());
-			Assert.assertEquals(String.valueOf("501"), flightVoForFlightHistory.getFlightNumber());
+			Assert.assertEquals(2, flightHistory.size());
+			FlightVoForFlightHistory fHistory = flightHistory.get(0);
+			FlightVoForFlightHistory bdHistory = flightHistory.get(1);
+			Assert.assertEquals(String.valueOf("150"), fHistory.getFlightId());
+			Assert.assertEquals(String.valueOf("501"), bdHistory.getFlightNumber());
+			Assert.assertEquals(String.valueOf("22"), bdHistory.getFlightId());
+			Assert.assertEquals(String.valueOf("501"), bdHistory.getFlightNumber());
 
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/gtas-parent/gtas-loader/src/main/java/gov/gtas/services/ServiceUtil.java
+++ b/gtas-parent/gtas-loader/src/main/java/gov/gtas/services/ServiceUtil.java
@@ -173,7 +173,7 @@ public class ServiceUtil implements LoaderServices {
 			return null;
 		}
 
-		Set<Passenger> flightPaxList;
+		Set<Passenger> passengerSet;
 		Passenger existingPassenger = null;
 
 		Long flightId = f.getId();
@@ -195,18 +195,18 @@ public class ServiceUtil implements LoaderServices {
 
 		// Resolve passenger by Flight -> pnr recordLocator# -> pnr REF number
 		if (newPaxHasRecordLocator && newPaxHasRef) {
-			flightPaxList = passengerRepository.getPassengerUsingREF(flightId, ref, recordLocator);
-			foundPassenger = !CollectionUtils.isEmpty(flightPaxList);
-			existingPassenger = foundPassenger ? flightPaxList.iterator().next() : null;
+			passengerSet = passengerRepository.getPassengerUsingREF(flightId, ref, recordLocator);
+			foundPassenger = !CollectionUtils.isEmpty(passengerSet);
+			existingPassenger = foundPassenger ? passengerSet.iterator().next() : null;
 		}
 
-		flightPaxList = passengerRepository.returnAPassengerFromParameters(flightId, firstName, lastName);
-		if (!foundPassenger && !CollectionUtils.isEmpty(flightPaxList)) {
+		passengerSet = passengerRepository.returnAPassengerFromParameters(flightId, firstName, lastName);
+		if (!foundPassenger && !CollectionUtils.isEmpty(passengerSet)) {
 
 			// Resolve passenger by passengerIdTag
 			if (newPaxHasGender && newPaxHasDob) {
 				String passengerIdTag = createPassengerIdTag(pvo);
-				for (Passenger pax : flightPaxList) {
+				for (Passenger pax : passengerSet) {
 					if (pax.getPassengerIDTag() != null) {
 						String paxIdTag = pax.getPassengerIDTag().getIdTag();
 						if (paxIdTag.equals(passengerIdTag)) {
@@ -221,7 +221,7 @@ public class ServiceUtil implements LoaderServices {
 			if (!foundPassenger && allowLoosenResolution) {
 				// Find passenger by First Name, Last Name, document# and dob
 				if (newPaxHasDocument && newPaxHasDob) {
-					for (Passenger pax : flightPaxList) {
+					for (Passenger pax : passengerSet) {
 						if (haveSameDocument(pax, pvo) && haveSameDateOfBirth(pax, pvo)) {
 							existingPassenger = pax;
 							foundPassenger = true;
@@ -232,7 +232,7 @@ public class ServiceUtil implements LoaderServices {
 
 				// Find passenger by First Name, Last Name, document# and gender
 				if (!foundPassenger && newPaxHasDocument && newPaxHasGender) {
-					for (Passenger pax : flightPaxList) {
+					for (Passenger pax : passengerSet) {
 						if (haveSameDocument(pax, pvo) && haveSameGender(pax, pvo)) {
 							existingPassenger = pax;
 							foundPassenger = true;
@@ -243,7 +243,7 @@ public class ServiceUtil implements LoaderServices {
 
 				// Find passenger by First Name, Last Name, and document#
 				if (!foundPassenger && newPaxHasDocument) {
-					for (Passenger pax : flightPaxList) {
+					for (Passenger pax : passengerSet) {
 						if (haveSameDocument(pax, pvo)) {
 							existingPassenger = pax;
 							foundPassenger = true;
@@ -254,7 +254,7 @@ public class ServiceUtil implements LoaderServices {
 
 				// Find passenger by First Name, Last Name, and dob
 				if (!foundPassenger && newPaxHasDob) {
-					for (Passenger pax : flightPaxList) {
+					for (Passenger pax : passengerSet) {
 						if (haveSameDateOfBirth(pax, pvo)) {
 							existingPassenger = pax;
 							break;
@@ -264,7 +264,7 @@ public class ServiceUtil implements LoaderServices {
 
 				// Find passenger by First Name, Last Name, and gender
 				if (!foundPassenger && newPaxHasGender) {
-					for (Passenger pax : flightPaxList) {
+					for (Passenger pax : passengerSet) {
 						if (haveSameGender(pax, pvo) && isNull(pax.getPassengerDetails().getDob())
 								&& isNull(pax.getDocuments())) {
 							existingPassenger = pax;
@@ -275,7 +275,7 @@ public class ServiceUtil implements LoaderServices {
 
 				// Find passenger by First Name and Last Name
 				if (!foundPassenger) {
-					for (Passenger pax : flightPaxList) {
+					for (Passenger pax : passengerSet) {
 						if (isNull(pax.getPassengerDetails().getDob()) && isNull(pax.getPassengerDetails().getGender())
 								&& isNull(pax.getDocuments())) {
 							existingPassenger = pax;

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/pnr/FlightPaxConditionBuilder.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/pnr/FlightPaxConditionBuilder.java
@@ -10,6 +10,7 @@ import gov.gtas.enumtype.EntityEnum;
 import gov.gtas.querybuilder.mappings.FlightPaxMapping;
 import gov.gtas.rule.builder.EntityConditionBuilder;
 
+@Deprecated
 public class FlightPaxConditionBuilder extends EntityConditionBuilder {
 
 	public FlightPaxConditionBuilder(final String drlVariableName) {

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/svc/util/TargetingResultUtils.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/svc/util/TargetingResultUtils.java
@@ -36,12 +36,12 @@ public class TargetingResultUtils {
 
 		// TODO: check for no rule hits, empty ruleHitDetailPassengerIdList
 		if (!ruleHitDetailPassengerIdList.isEmpty()) {
-			Set<FlightPax> allFlightPaxByPassengerId = passengerService
-					.findFlightPaxFromPassengerIds(ruleHitDetailPassengerIdList);
+			Set<Passenger> passengerFromPassengerIds = passengerService
+					.findPassengerFromPassengerIds(ruleHitDetailPassengerIdList);
 
-			for (FlightPax flightPax : allFlightPaxByPassengerId) {
-				Long passengerId = flightPax.getPassengerId();
-				Long flightId = flightPax.getFlightId();
+			for (Passenger p : passengerFromPassengerIds) {
+				Long passengerId = p.getId();
+				Long flightId = p.getFlight().getId();
 				if (passengerFlightMap.containsKey(passengerId)) {
 					passengerFlightMap.get(passengerId).add(flightId);
 				} else {

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/common/BagStatisticCalculator.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/common/BagStatisticCalculator.java
@@ -1,0 +1,53 @@
+package gov.gtas.common;
+
+import gov.gtas.model.Bag;
+import gov.gtas.model.BagMeasurements;
+import gov.gtas.model.Passenger;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BagStatisticCalculator {
+    private int bagCount;
+    private double bagWeight;
+    private Set<Bag> bagsSet;
+
+    public BagStatisticCalculator(Passenger passenger) {
+        this.bagsSet = passenger.getBags();
+        this.bagCount = 0;
+        this.bagWeight = 0;
+    }
+
+    public BagStatisticCalculator(Set<Bag> bagsSet) {
+        this.bagsSet = bagsSet;
+        this.bagCount = 0;
+        this.bagWeight = 0;
+    }
+
+    public int getBagCount() {
+        return bagCount;
+    }
+
+    public double getBagWeight() {
+        return bagWeight;
+    }
+
+    public BagStatisticCalculator invoke(String bagType) {
+        Set<BagMeasurements> bagMeasurementsSet = new HashSet<>();
+        for (Bag paxBag : bagsSet) {
+            if (bagType.equalsIgnoreCase(paxBag.getData_source()))
+                if (paxBag.getBagMeasurements() != null) {
+                    BagMeasurements bagMeasurements = paxBag.getBagMeasurements();
+                    if (bagMeasurementsSet.add(bagMeasurements)) {
+                        if (bagMeasurements.getBagCount() != null) {
+                            bagCount += bagMeasurements.getBagCount();
+                        }
+                        if (bagMeasurements.getWeight() != null) {
+                            bagWeight += bagMeasurements.getWeight();
+                        }
+                    }
+                }
+        }
+        return this;
+    }
+}

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/SearchController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/SearchController.java
@@ -50,7 +50,7 @@ public class SearchController {
 			@RequestParam(value = "column") String column, @RequestParam(value = "dir") String dir)
 			throws InvalidQueryException {
 
-		Passenger pax = paxService.findByIdWithFlightPaxAndDocuments(paxId);
+		Passenger pax = paxService.findByIdWithFlightAndDocuments(paxId);
 		LinkAnalysisDto queryResults = searchService.findPaxLinks(pax, pageNumber, pageSize, column, dir);
 		return new JsonServiceResponse(Status.SUCCESS, "success", queryResults);
 	}

--- a/gtas-parent/gtas-webapp/src/main/webapp/pax/paxTabs.html
+++ b/gtas-parent/gtas-webapp/src/main/webapp/pax/paxTabs.html
@@ -716,7 +716,7 @@
                                 <div class="cbp-card-container full-width">
                                     <div class="cbp-card cbp-card-shadow">
                                         <h4 class="h-label no-margin-top">
-                                            {{'bag.totalpnrbaggage' | translate}} ({{passenger.pnrVo.totalbagCount || 0}})&nbsp;&nbsp;&nbsp;
+                                            {{'bag.totalpnrbaggage' | translate}} ({{passenger.pnrVo.bagCount || 0}})&nbsp;&nbsp;&nbsp;
                                             <span class="right-header">{{'bag.baggageweight' | translate}} ({{passenger.pnrVo.baggageWeight}} Kg)</span>
                                         </h4>
                                         <div class="no-pad-top panel-body flex flex-vert ie-fix-md">

--- a/gtas-parent/gtas-webapp/src/test/java/gov/gtas/controller/PassengerDetailsControllerTest.java
+++ b/gtas-parent/gtas-webapp/src/test/java/gov/gtas/controller/PassengerDetailsControllerTest.java
@@ -71,14 +71,14 @@ public class PassengerDetailsControllerTest {
 	public void passengerDetailControllerHappyPathTest() throws SQLException {
 		Passenger wally = TestData.getPassenger();
 		Mockito.when(fService.findById(2L)).thenReturn(TestData.getFlight());
-		Mockito.when(pService.findByIdWithFlightPaxAndDocuments(1L)).thenReturn(wally);
+		Mockito.when(pService.findByIdWithFlightAndDocuments(1L)).thenReturn(wally);
 		List<Pnr> pnrs = TestData.getPnrList();
 		Mockito.when(pnrService.findPnrByPassengerIdAndFlightId(1L, 2L)).thenReturn(pnrs);
 		Mockito.when(bagRepository.findFromFlightAndPassenger(2L, 1L)).thenReturn(TestData.getBags());
 		Mockito.when(apisMessageRepository.findByFlightIdAndPassengerId(2L, 1L))
 				.thenReturn(Collections.singletonList(TestData.getApisMessage()));
-		Mockito.when(apisMessageRepository.findFlightPaxByFlightIdandPassengerId(2L, 1L))
-				.thenReturn(Collections.singletonList(TestData.getFlightPax()));
+		Mockito.when(apisMessageRepository.findPaxByFlightIdandPassengerId(2L, 1L))
+				.thenReturn(TestData.getPassenger());
 		PassengerVo passengerVo = passengerDetailsController.getPassengerByPaxIdAndFlightId("1", "2");
 		Assert.assertNotNull(passengerVo);
 	}


### PR DESCRIPTION
The FlightPax class combines several different tables into a single class. This confused where the actual data was and so it was decided to remove the table.

Due to the structure having links to both flight and passenger, apis information and baginformation this class was used in several places throughout the application.

The work encompassed here deprecates the FlightPax and removes it from business logic in the application.

I kept the class in the rule engine as well as kept the logic to load into the database. This will be removed in a future release.