### PR TITLE
Fix/user roles

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/constant/GtasSecurityConstants.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/constant/GtasSecurityConstants.java
@@ -46,8 +46,6 @@ public class GtasSecurityConstants {
 
 	public static final String PRIVILEGES_ADMIN_AND_MANAGE_HITS = "hasAnyAuthority('Admin', 'Manage Hits')";
 
-	public static final String PRIVILEGES_ADMIN_AND_MANAGE_CASES = "hasAnyAuthority('Admin', 'Manage Cases')";
-
 	// This combo role is generated because of a specific edge case: Manage queries
 	// can see list of passengers in nearly all facets EXCEPT for after flight grid
 	// selection, this makes little sense

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/Role.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/Role.java
@@ -5,6 +5,8 @@
  */
 package gov.gtas.model;
 
+import org.hibernate.annotations.Immutable;
+
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
@@ -17,6 +19,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
+@Immutable
 @Entity
 @Table(name = "role")
 public class Role implements Serializable {

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/RoleService.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/RoleService.java
@@ -9,11 +9,14 @@ import static gov.gtas.constant.GtasSecurityConstants.PRIVILEGE_ADMIN;
 
 import java.util.Set;
 
+import gov.gtas.model.Role;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 public interface RoleService {
 
 	@PreAuthorize(PRIVILEGE_ADMIN)
 	public Set<RoleData> findAll();
+
+	public Set<Role> getValidRoles(Set<RoleData> roleDataSet);
 
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/RoleServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/RoleServiceImpl.java
@@ -5,11 +5,8 @@
  */
 package gov.gtas.services.security;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
+import java.util.*;
+import java.util.stream.*;
 
 import javax.annotation.Resource;
 import javax.persistence.EntityManager;
@@ -51,4 +48,20 @@ public class RoleServiceImpl implements RoleService {
 
 		return roles;
 	}
+
+	public Set<Role> getValidRoles(Set<RoleData> roleDataSet) {
+		Set<Role> validRoles = new HashSet<Role>();
+		Iterable<Role> allRoles = roleRepository.findAll();
+		Set<Role> rawRoles = roleServiceUtil.mapEntityCollectionFromRoleDataSet(roleDataSet);
+
+		for (Role raw : rawRoles) {
+			Role validRole = StreamSupport.stream(allRoles.spliterator(), false)
+					.filter(r -> (r.getRoleDescription().equals(raw.getRoleDescription()))).findFirst().get();
+
+			if (validRole != null) validRoles.add(validRole);
+		}
+
+		return validRoles;
+	}
+
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/RoleServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/RoleServiceImpl.java
@@ -49,13 +49,29 @@ public class RoleServiceImpl implements RoleService {
 		return roles;
 	}
 
+	/*
+	Return a set of matching roles from the DB containing either the admin role or a collection
+	of non-admin roles.
+	 */
 	public Set<Role> getValidRoles(Set<RoleData> roleDataSet) {
 		Set<Role> validRoles = new HashSet<Role>();
 		Iterable<Role> allRoles = roleRepository.findAll();
+		Role admin = StreamSupport.stream(allRoles.spliterator(), false)
+				.filter(r -> (r.getRoleDescription().equals("Admin"))).findFirst().get();
 
+		// admin role
+		for (RoleData rd : roleDataSet) {
+			if (rd.getRoleDescription().equals(admin.getRoleDescription())) {
+				validRoles.add(admin);
+				return validRoles;
+			}
+		}
+
+		// non-admin roles
 		for (RoleData raw : roleDataSet) {
+			String rawDescription = raw.getRoleDescription();
 			Role validRole = StreamSupport.stream(allRoles.spliterator(), false)
-					.filter(r -> (r.getRoleDescription().equals(raw.getRoleDescription()))).findFirst().get();
+					.filter(r -> r.getRoleDescription().equals(rawDescription)).findFirst().orElse(null);
 
 			if (validRole != null) validRoles.add(validRole);
 		}

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/RoleServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/RoleServiceImpl.java
@@ -52,9 +52,8 @@ public class RoleServiceImpl implements RoleService {
 	public Set<Role> getValidRoles(Set<RoleData> roleDataSet) {
 		Set<Role> validRoles = new HashSet<Role>();
 		Iterable<Role> allRoles = roleRepository.findAll();
-		Set<Role> rawRoles = roleServiceUtil.mapEntityCollectionFromRoleDataSet(roleDataSet);
 
-		for (Role raw : rawRoles) {
+		for (RoleData raw : roleDataSet) {
 			Role validRole = StreamSupport.stream(allRoles.spliterator(), false)
 					.filter(r -> (r.getRoleDescription().equals(raw.getRoleDescription()))).findFirst().get();
 

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserService.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserService.java
@@ -91,6 +91,8 @@ public interface UserService {
 
 	Set<UserGroup> fetchUserGroups(final String userId);
 
+	UserData updatePassword(String userId, String password);
+
 	boolean isAdminUser(String userId);
 
 	boolean treatAsOneDay(String userId);

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserServiceImpl.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import gov.gtas.services.security.RoleService;
 
 import freemarker.template.TemplateException;
 import gov.gtas.constant.CommonErrorConstants;
@@ -67,7 +68,10 @@ public class UserServiceImpl implements UserService {
 	
 	@Resource
 	private PasswordResetTokenRepository passwordResetTokenRepository;
-	
+
+	@Resource
+	private RoleService roleService;
+
 	@Value("${user.group.default}")
 	private Long defaultUserGroupId;
 	
@@ -89,7 +93,7 @@ public class UserServiceImpl implements UserService {
 			Set<Role> roleCollection = roleServiceUtil.getAdminRoleIfExists(userData.getRoles());
 			
 			if (roleCollection.isEmpty()) {
-				roleCollection = roleServiceUtil.mapEntityCollectionFromRoleDataSet(userData.getRoles());
+				roleCollection = roleService.getValidRoles(userData.getRoles());
 			}
 			 
 			userEntity.setRoles(roleCollection);
@@ -135,13 +139,12 @@ public class UserServiceImpl implements UserService {
 			entity.setArchived(mappedEnity.getArchived());
 			entity.setActive(mappedEnity.getActive());
 			entity.setPhoneNumber(mappedEnity.getPhoneNumber());
-			if (data.getRoles() != null && !data.getRoles().isEmpty()) {			
-				Set<Role> oRoles = entity.getRoles();
-				oRoles.clear();
+			if (data.getRoles() != null && !data.getRoles().isEmpty()) {
+				Set<Role> oRoles = new HashSet<Role>();
 				Set<Role> roleCollection = roleServiceUtil.getAdminRoleIfExists(data.getRoles());
 				
 				if (roleCollection.isEmpty()) {
-					 roleCollection = roleServiceUtil.mapEntityCollectionFromRoleDataSet(data.getRoles());
+					 roleCollection = roleService.getValidRoles(data.getRoles());
 				}
 				
 				oRoles.addAll(roleCollection);
@@ -248,11 +251,10 @@ public class UserServiceImpl implements UserService {
 			entity.setActive(mappedEnity.getActive());
 			if (data.getRoles() != null) {// && !data.getRoles().isEmpty()) {
 				if (!data.getRoles().isEmpty()) {
-					Set<Role> oRoles = entity.getRoles();
-					oRoles.clear();
+					Set<Role> oRoles = new HashSet<Role>();
 					Set<Role> roleCollection = roleServiceUtil.getAdminRoleIfExists(data.getRoles());
 					if (roleCollection.isEmpty()) {
-						roleCollection = roleServiceUtil.mapEntityCollectionFromRoleDataSet(data.getRoles());
+						roleCollection = roleService.getValidRoles(data.getRoles());
 					}
 					
 					oRoles.addAll(roleCollection);

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserServiceImpl.java
@@ -88,16 +88,10 @@ public class UserServiceImpl implements UserService {
 		User userEntity = userServiceUtil.mapUserEntityFromUserData(userData);
 		userEntity.setPassword((new BCryptPasswordEncoder()).encode(userEntity.getPassword()));
 		userEntity.setArchived(false); //Default do not archive new users.
-		if (userData.getRoles() != null) {
-			//check if Admin role is passed
-			Set<Role> roleCollection = roleServiceUtil.getAdminRoleIfExists(userData.getRoles());
-			
-			if (roleCollection.isEmpty()) {
-				roleCollection = roleService.getValidRoles(userData.getRoles());
-			}
-			 
+
+		Set<Role> roleCollection = roleService.getValidRoles(userData.getRoles());
+
 			userEntity.setRoles(roleCollection);
-		}
 		User newUserEntity = userRepository.save(userEntity);
 		UserGroup defaultUserGroup = userGroupRepository.findById(defaultUserGroupId)
 				.orElseThrow(RuntimeException::new);
@@ -121,6 +115,7 @@ public class UserServiceImpl implements UserService {
 		return userServiceUtil.getUserDataListFromEntityCollection(usersCollection);
 	}
 
+	@Deprecated
 	@Override
 	@Transactional
 	public UserData update(UserData data) {
@@ -155,6 +150,17 @@ public class UserServiceImpl implements UserService {
 			return userServiceUtil.mapUserDataFromEntity(savedEntity);
 		}
 		return null;
+	}
+
+		/* Update the user password only. */
+	@Transactional
+	public UserData updatePassword(String userId, String password) {
+		User existingUser = fetchUser(userId.toUpperCase());
+
+			existingUser.setPassword(getEncodedPassword(password));
+
+			User savedEntity = userRepository.save(existingUser);
+			return userServiceUtil.mapUserDataFromEntity(savedEntity);
 	}
 
 	@Override
@@ -200,7 +206,7 @@ public class UserServiceImpl implements UserService {
 	 *
 	 * @param userId
 	 *            the ID of the user to fetch.
-	 * @return true if the user has Admin role flase otherwise
+	 * @return true if the user has Admin role false otherwise
 	 */
 
 	public boolean isAdminUser(String userId) {
@@ -225,51 +231,34 @@ public class UserServiceImpl implements UserService {
 
 	}
 
+	/*
+		Update all user data except the password. The password is handled by a separate function
+	 */
 	@Override
+	@Transactional
 	public UserData updateByAdmin(UserData data) {
-		BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-		User entity = userRepository.findOne(data.getUserId());
+		User entity = fetchUser(data.getUserId());	//returns error if null
 
-		User mappedEnity = userServiceUtil.mapUserEntityFromUserData(data);
-		if (entity != null) {
-			entity.setFirstName(mappedEnity.getFirstName());
-			entity.setLastName(mappedEnity.getLastName());
-			entity.setEmail(mappedEnity.getEmail());
-			entity.setEmailEnabled(mappedEnity.getEmailEnabled());
-			entity.setHighPriorityHitsEmailNotification(mappedEnity.getHighPriorityHitsEmailNotification());
-			entity.setArchived(mappedEnity.getArchived());
-			entity.setPhoneNumber(mappedEnity.getPhoneNumber());
-			
-			if (data.getPassword() != null && !data.getPassword().isEmpty()) {
-				if (!BCRYPT_PATTERN.matcher(mappedEnity.getPassword()).matches()) {
-					entity.setPassword(passwordEncoder.encode(mappedEnity.getPassword()));
-				} else {
-					entity.setPassword(mappedEnity.getPassword());
-				}
-			}
+		User mappedEntity = userServiceUtil.mapUserEntityFromUserData(data);
 
-			entity.setActive(mappedEnity.getActive());
-			if (data.getRoles() != null) {// && !data.getRoles().isEmpty()) {
-				if (!data.getRoles().isEmpty()) {
-					Set<Role> oRoles = new HashSet<Role>();
-					Set<Role> roleCollection = roleServiceUtil.getAdminRoleIfExists(data.getRoles());
-					if (roleCollection.isEmpty()) {
-						roleCollection = roleService.getValidRoles(data.getRoles());
-					}
-					
-					oRoles.addAll(roleCollection);
-					entity.setRoles(oRoles);
-				} else {
-					entity.setRoles(new HashSet<Role>());
-				}
-			}
+		entity.setFirstName(mappedEntity.getFirstName());
+		entity.setLastName(mappedEntity.getLastName());
+		entity.setEmail(mappedEntity.getEmail());
+		entity.setEmailEnabled(mappedEntity.getEmailEnabled());
+		entity.setHighPriorityHitsEmailNotification(mappedEntity.getHighPriorityHitsEmailNotification());
+		entity.setArchived(mappedEntity.getArchived());
+		entity.setPhoneNumber(mappedEntity.getPhoneNumber());
+		entity.setActive(mappedEntity.getActive());
 
-			User savedEntity = userRepository.save(entity);
-			logger.debug("Updated by Admin successfully in " + this.getClass().getName());
-
-			return userServiceUtil.mapUserDataFromEntity(savedEntity);
+		if (data.getRoles() != null && !data.getRoles().isEmpty()) {
+			Set<Role> validatedRoles = roleService.getValidRoles(data.getRoles());
+			entity.setRoles(validatedRoles);
 		}
-		return null;
+
+		User savedEntity = userRepository.save(entity);
+		logger.debug("Updated by Admin successfully in " + this.getClass().getName());
+
+		return userServiceUtil.mapUserDataFromEntity(savedEntity);
 	}
 
 	@Override
@@ -307,6 +296,17 @@ public class UserServiceImpl implements UserService {
 		
 		return isValidToken(prt);
 		
+	}
+
+	private String getEncodedPassword(String password) {
+		if (password == null) return null;
+
+		BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+		if (!BCRYPT_PATTERN.matcher(password).matches()) {
+			return passwordEncoder.encode(password);
+		}
+		return password;
 	}
 	
 	private Date calculateExpiryDate() {

--- a/gtas-parent/gtas-commons/src/main/resources/sql/gtas_data.sql
+++ b/gtas-parent/gtas-commons/src/main/resources/sql/gtas_data.sql
@@ -9,9 +9,7 @@ INSERT INTO `role` VALUES ('4', 'Manage Watch List');
 INSERT INTO `role` VALUES ('5', 'Manage Rules');
 INSERT INTO `role` VALUES ('6', 'SysAdmin');
 INSERT INTO `role` VALUES ('7', 'Manage Hits');
-INSERT INTO `role` VALUES ('8', 'Manage Cases');
-INSERT INTO `role` VALUES ('9', 'View Flights');
-
+INSERT INTO `role` VALUES ('8', 'View Flights');
 
 -- ----------------------------
 -- Users
@@ -26,6 +24,7 @@ INSERT INTO gtas.user (user_id, active, email, first_name, high_priority_hits_em
 
 INSERT INTO `user_role` (`user_id`, `role_id`) VALUES ('ADMIN', 1);
 INSERT INTO `user_role` (`user_id`, `role_id`) VALUES ('GTAS', 5);
+INSERT INTO `user_role` (`user_id`, `role_id`) VALUES ('GTAS', 8);
 
 -- ----------------------------
 -- Records of flight_direction
@@ -34,7 +33,7 @@ INSERT INTO `user_role` (`user_id`, `role_id`) VALUES ('GTAS', 5);
 INSERT INTO `flight_direction` VALUES (1,'I', 'Inbound');
 INSERT INTO `flight_direction` VALUES (2,'O', 'Outbound');
 INSERT INTO `flight_direction` VALUES (3,'C', 'Continuance');
-INSERT INTO `flight_direction` VALUES (4,'A', 'Any');
+INSERT INTO `flight_direction` VALUES (4,'A', 'Any'); 
 
 -- ----------------------------
 -- Records of app_configuration
@@ -85,9 +84,9 @@ INSERT INTO gtas.ug_hit_category_join (ug_id, hc_id) VALUES (1, 3);
 INSERT INTO gtas.ug_hit_category_join (ug_id, hc_id) VALUES (1, 4);
 INSERT INTO gtas.ug_hit_category_join (ug_id, hc_id) VALUES (1, 5);
 
-INSERT INTO gtas.note_type (id, created_at, created_by, updated_at, updated_by, nt_type, archived) VALUES (1, null, null, null, null, 'GENERAL_PASSENGER', false);
-INSERT INTO gtas.note_type (id, created_at, created_by, updated_at, updated_by, nt_type, archived) VALUES (2, null, null, null, null, 'DELETED', false);
-INSERT INTO gtas.note_type (id, created_at, created_by, updated_at, updated_by, nt_type) VALUES (3, null, null, null, null, 'LOOKOUT', false);
+INSERT INTO gtas.note_type (id, created_at, created_by, updated_at, updated_by, nt_type, archived) VALUES (1, null, null, null, null, 'General', false);
+INSERT INTO gtas.note_type (id, created_at, created_by, updated_at, updated_by, nt_type, archived) VALUES (2, null, null, null, null, 'Deleted', false);
+INSERT INTO gtas.note_type (id, created_at, created_by, updated_at, updated_by, nt_type, archived) VALUES (3, null, null, null, null, 'Lookout', false);
 
 -- ----------------------------
 -- Manual Hit HitMaker Population

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/UserController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/UserController.java
@@ -165,7 +165,7 @@ public class UserController {
 		if (userData.getPassword() != null && !userData.getPassword().isEmpty()) {
 			if (validator.isValid(userData.getPassword(), userData.getUserId())) {
 				rUserData = userService.updateByAdmin(userData);
-				logger.info("The User Information is updated sucessfully for " + userData.getUserId());
+				logger.info("The User Information is updated successfully for " + userData.getUserId());
 				return new JsonServiceResponse(Status.SUCCESS, validator.getErrMessage(), rUserData);
 			} else {
 				logger.error("The User Information is not updated due to errors for " + userData.getUserId() + " "
@@ -176,7 +176,7 @@ public class UserController {
 
 		else {
 			rUserData = userService.updateByAdmin(userData);
-			logger.info("The User Information is updated sucessfully for " + userData.getUserId());
+			logger.info("The User Information is updated successfully for " + userData.getUserId());
 			return new JsonServiceResponse(Status.SUCCESS, validator.getErrMessage(), rUserData);
 		}
 	}
@@ -241,7 +241,6 @@ public class UserController {
 			return new JsonServiceResponse(Status.FAILURE, errorMessage);
 		}
 
-		UserData user = userService.findById(dto.getUsername());
 		Validator validator = this.new Validator();
 
 		if (!dto.getPassword().equals(dto.getPasswordConfirm())) {
@@ -251,8 +250,7 @@ public class UserController {
 			return new JsonServiceResponse(Status.FAILURE, validator.getErrMessage(), dto);
 		}
 
-		user.setPassword(dto.getPassword());
-		userService.update(user);
+		userService.updatePassword(dto.getUsername(), dto.getPassword());
 
 		return new JsonServiceResponse(Status.SUCCESS, "Your password has been reset!");
 
@@ -332,8 +330,7 @@ public class UserController {
 		}
 
 		// change password
-		user.setPassword(newPassword);
-		userService.update(user);
+		userService.updatePassword(user.getUserId(), newPassword);
 
 		return new JsonServiceResponse(Status.SUCCESS, user.getUserId() + "'s password has successfully been changed!");
 	}


### PR DESCRIPTION
- Removed Manage Cases role
- Roles entity immutable
- User Roles validated against DB - currently matched on description only but more updates are necessary to remove hard-coded references.
- misc refactoring of redundant code.

So the updates affect the create and update paths on the User entity. Need to verify that admins/non-admins can change their own password successfully under the site header, and that admins can:
- edit the roles of other users such that View Flights is always saved with the collection of selected non-admin roles, or that the Admin role is saved by itself no matter what other roles were selected.
- Edit the password of other users as expected
- Create a user as expected.

The issue with creating invalid roles can only be tested by changing the default role id in UserModal.js to 1 and the description to any random text. Then if you attempt to save any combination of roles excluding admin, you should see that the invalid one does not get created in the roles table or associated with the user when you go back to edit them. 