### PR TITLE
Save And Run Rules on Segments

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/enumtype/EntityEnum.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/enumtype/EntityEnum.java
@@ -47,6 +47,8 @@ public enum EntityEnum {
 
 	FLIGHT_PAX("FLIGHT PAX", "FlightPax", "flightpax", ".flightPaxList"),
 
+	SAVED_SEGMENT("SAVED_SEGMENT", "SavedSegment", "savedSegment", ".savedSegments"),
+
 	SEAT("SEAT", "Seat", "seat", ".seatAssignments"),
 
 	DATA_RETENTION_STATUS("DATA RETENTION STATUS", "DataRetentionStatus", "drs", ".dataRetentionStatus"),

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/Pnr.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/Pnr.java
@@ -145,6 +145,9 @@ public class Pnr extends Message {
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "pnr")
 	private List<PaymentForm> paymentForms = new ArrayList<>();
 
+	@OneToMany(cascade = CascadeType.ALL)
+	private List<SavedSegment> savedSegments = new ArrayList<>();
+
 	@ManyToMany(targetEntity = DwellTime.class, cascade = { CascadeType.ALL })
 	@JoinTable(name = "pnr_dwelltime", joinColumns = @JoinColumn(name = "pnr_id"), inverseJoinColumns = @JoinColumn(name = "dwell_id"))
 	private Set<DwellTime> dwellTimes = new HashSet<>();
@@ -425,4 +428,11 @@ public class Pnr extends Message {
 		this.passengers = passengers;
 	}
 
+	public List<SavedSegment> getSavedSegments() {
+		return savedSegments;
+	}
+
+	public void setSavedSegments(List<SavedSegment> savedSegments) {
+		this.savedSegments = savedSegments;
+	}
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/SavedSegment.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/SavedSegment.java
@@ -1,0 +1,59 @@
+package gov.gtas.model;
+
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "saved_segment")
+public class SavedSegment extends BaseEntityAudit {
+
+    private String rawSegment;
+    private String regex;
+    private String segmentName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pnr_id", referencedColumnName = "id")
+    private Pnr pnr;
+
+    public SavedSegment(String segmentName, String segmentText, String regex) {
+        this.rawSegment = segmentText;
+        this.segmentName = segmentName;
+        this.regex = regex;
+    }
+
+    public SavedSegment() {
+
+    }
+
+    public String getRawSegment() {
+        return rawSegment;
+    }
+
+    public void setRawSegment(String rawSegment) {
+        this.rawSegment = rawSegment;
+    }
+
+    public String getRegex() {
+        return regex;
+    }
+
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    public String getSegmentName() {
+        return segmentName;
+    }
+
+    public void setSegmentName(String segmentName) {
+        this.segmentName = segmentName;
+    }
+
+    public Pnr getPnr() {
+        return pnr;
+    }
+
+    public void setPnr(Pnr pnr) {
+        this.pnr = pnr;
+    }
+}

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/JPQLGenerator.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/JPQLGenerator.java
@@ -544,6 +544,10 @@ public class JPQLGenerator {
 			joinCondition = Constants.LEFT_JOIN + EntityEnum.PNR.getAlias() + EntityEnum.PHONE.getEntityReference()
 					+ " " + EntityEnum.PHONE.getAlias();
 			break;
+		case Constants.SAVED_SEGMENT:
+			joinCondition = Constants.LEFT_JOIN + EntityEnum.PNR.getAlias() + EntityEnum.SAVED_SEGMENT.getEntityReference()
+					+ " " + EntityEnum.SAVED_SEGMENT.getAlias();
+			break;
 		case Constants.PNR:
 			if (queryType == EntityEnum.FLIGHT) {
 				joinCondition = Constants.LEFT_JOIN + EntityEnum.FLIGHT.getAlias() + EntityEnum.PNR.getEntityReference()
@@ -575,11 +579,16 @@ public class JPQLGenerator {
 		if (entity != null && !entity.isEmpty()) {
 
 			for (EntityEnum entityEnum : entity) {
-				if (entityEnum == EntityEnum.ADDRESS || entityEnum == EntityEnum.CREDIT_CARD
-						|| entityEnum == EntityEnum.EMAIL || entityEnum == EntityEnum.FREQUENT_FLYER
-						|| entityEnum == EntityEnum.PHONE || entityEnum == EntityEnum.PNR
-						|| entityEnum == EntityEnum.TRAVEL_AGENCY || entityEnum == EntityEnum.DWELL_TIME
-						|| entityEnum == EntityEnum.FORM_OF_PAYMENT) {
+				if (entityEnum == EntityEnum.ADDRESS
+						|| entityEnum == EntityEnum.CREDIT_CARD
+						|| entityEnum == EntityEnum.EMAIL
+						|| entityEnum == EntityEnum.FREQUENT_FLYER
+						|| entityEnum == EntityEnum.PHONE
+						|| entityEnum == EntityEnum.PNR
+						|| entityEnum == EntityEnum.TRAVEL_AGENCY
+						|| entityEnum == EntityEnum.DWELL_TIME
+						|| entityEnum == EntityEnum.FORM_OF_PAYMENT
+						|| entityEnum == EntityEnum.SAVED_SEGMENT) {
 					return true;
 				}
 			}

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/constants/Constants.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/constants/Constants.java
@@ -29,6 +29,7 @@ public final class Constants {
 	public static final String HITS = "HITSSUMMARY";
 	public static final String PASSENGER = "PASSENGER";
 	public static final String PHONE = "PHONE";
+	public static final String SAVED_SEGMENT = "SAVEDSEGMENT";
 	public static final String PNR = "PNR";
 	public static final String AGENCY = "AGENCY";
 	public static final String DWELLTIME = "DWELLTIME";

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/mappings/SavedSegmentMapping.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/mappings/SavedSegmentMapping.java
@@ -1,0 +1,45 @@
+package gov.gtas.querybuilder.mappings;
+
+import gov.gtas.enumtype.TypeEnum;
+
+public enum  SavedSegmentMapping implements IEntityMapping {
+
+    REGEX("regex", "regex",TypeEnum.STRING.getType()),
+    RAW_SEGMENT("rawSegment", "rawSegment",TypeEnum.STRING.getType() ),
+    SEGMENT_NAME("segmentName", "segmentName",TypeEnum.STRING.getType() );
+
+    private String fieldName;
+    private String friendlyName;
+    private String fieldType;
+    private boolean displayField;
+
+    private SavedSegmentMapping(String fieldName, String friendlyName, String fieldType, boolean displayField) {
+        this.fieldName = fieldName;
+        this.friendlyName = friendlyName;
+        this.fieldType = fieldType;
+        this.displayField = displayField;
+    }
+
+    private SavedSegmentMapping(String fieldName, String friendlyName, String fieldType) {
+        this(fieldName, friendlyName, fieldType, true);
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public String getFriendlyName() {
+        return friendlyName;
+    }
+
+    public String getFieldType() {
+        return fieldType;
+    }
+
+    /**
+     * @return the displayField
+     */
+    public boolean isDisplayField() {
+        return displayField;
+    }
+}

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/validation/util/QueryValidationUtils.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/querybuilder/validation/util/QueryValidationUtils.java
@@ -162,6 +162,9 @@ public class QueryValidationUtils {
 				case Constants.PHONE:
 					validField = validateField(PhoneMapping.values(), field);
 					break;
+				case Constants.SAVED_SEGMENT:
+					validField = validateField(SavedSegmentMapping.values(), field);
+					break;
 				case Constants.PNR:
 					validField = validateField(PNRMapping.values(), field);
 					break;

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/PnrRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/PnrRepository.java
@@ -77,6 +77,10 @@ public interface PnrRepository extends MessageRepository<Pnr> {
 	List<Object[]> getCreditCardByIds(@Param("pnrIds") Set<Long> pnrIds);
 
 	@Transactional
+	@Query(" SELECT pnr.id, ss from Pnr pnr join pnr.savedSegments ss where pnr.id in :pnrIds ")
+	List<Object[]> getSegmentsByPnr(@Param("pnrIds") Set<Long> pnrIds);
+
+	@Transactional
 	@Query(" SELECT pnr.id, email from Pnr pnr join pnr.emails email where pnr.id in :pnrIds ")
 	List<Object[]> getEmailByPnrIds(@Param("pnrIds") Set<Long> pnrIds);
 

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/FlightServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/FlightServiceImpl.java
@@ -100,6 +100,9 @@ public class FlightServiceImpl implements FlightService {
 
 			if (f.getFlightHitsFuzzy() != null) {
 				fuzzyHits = f.getFlightHitsFuzzy().getHitCount();
+				if (fuzzyHits == null) {
+					fuzzyHits = 0;
+				}
 				vo.setFuzzyHitCount(fuzzyHits);
 			}
 			if (f.getFlightHitsGraph() != null) {

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/PnrService.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/PnrService.java
@@ -42,6 +42,5 @@ public interface PnrService {
 	Map<Long, Set<Agency>> createTravelAgencyMap(Set<Long> pnrIds);
 	Map<Long, Set<Passenger>> getPassengersOnPnr(Set<Long> pids, Set<Long> hitApisIds);
 	Set<Pnr> pnrMessageWithFlightInfo(Set<Long> pids,Set<Long> messageIds, Long flightId);
-
-
-	}
+    Map<Long, Set<SavedSegment>> createSegmentMap(Set<Long> pnrIds);
+}

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/PnrServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/PnrServiceImpl.java
@@ -385,7 +385,16 @@ public class PnrServiceImpl implements PnrService {
 		}
 		return phoneMap;
 	}
-
+	public Map<Long, Set<SavedSegment>> createSegmentMap(Set<Long> pnrIds) {
+		Map<Long, Set<SavedSegment>> segmentMap = new HashMap<>();
+		List<Object[]> segmentList = pnrRepository.getSegmentsByPnr(pnrIds);
+		for (Object[] answerKey : segmentList) {
+			Long pnrId = (Long) answerKey[0];
+			SavedSegment savedSegment = (SavedSegment) answerKey[1];
+			processObject(savedSegment, segmentMap, pnrId);
+		}
+		return segmentMap;
+	}
 	public Map<Long, Set<Address>> createAddressMap(Set<Long> pnrIds) {
 		Map<Long, Set<Address>> addressMap = new HashMap<>();
 		List<Object[]> addressList = pnrRepository.getAddressesByPnr(pnrIds);
@@ -416,6 +425,8 @@ public class PnrServiceImpl implements PnrService {
 		}
 		return objectMap;
 	}
+
+
 
 	public Set<Pnr> pnrMessageWithFlightInfo(Set<Long> pids,Set<Long> messageIds, Long flightId) {
 		return pnrRepository.pnrMessageWithFlightInfo(pids, messageIds, flightId);

--- a/gtas-parent/gtas-commons/src/main/resources/default.application.properties
+++ b/gtas-parent/gtas-commons/src/main/resources/default.application.properties
@@ -280,4 +280,5 @@ omni.derogReplace.batchSize=300
 # Title and description to be used on derog hits received from Omni.
 omni.derog_hit.title=Kaizen External Hit
 omni.derog_hit.description=This passenger closely matches at least one derog category, according to Kaizen's proprietary inference technology.
-
+segments.extraparse=
+segments.regex=

--- a/gtas-parent/gtas-commons/src/test/java/gov/gtas/querybuilder/JPQLGeneratorTest.java
+++ b/gtas-parent/gtas-commons/src/test/java/gov/gtas/querybuilder/JPQLGeneratorTest.java
@@ -226,6 +226,43 @@ public class JPQLGeneratorTest {
 		Assert.assertEquals(expectedQuery, query);
 	}
 
+
+	@Test
+	public void testContainsSegmentClause() throws InvalidQueryRepositoryException {
+		String expectedQuery = "select distinct p.id, p, " +
+				"p.flight from Passenger p " +
+				"left join p.flight f  " +
+				"left join p.pnrs pnr " +
+				"left join pnr.savedSegments savedSegment " +
+				"where (savedSegment.rawMessage LIKE ?1)" +
+				" and (((p.dataRetentionStatus.maskedAPIS = false" +
+				" and p.dataRetentionStatus.hasApisMessage = true)" +
+				" or (p.dataRetentionStatus.maskedPNR = false" +
+				" and p.dataRetentionStatus.hasPnrMessage = true))" +
+				" and ((p.dataRetentionStatus.deletedAPIS = false" +
+				" and p.dataRetentionStatus.hasApisMessage = true)" +
+				" or (p.dataRetentionStatus.deletedPNR = false" +
+				" and p.dataRetentionStatus.hasPnrMessage = true)))";
+
+		QueryObject mockQueryObject  = new QueryObject();
+		QueryTerm mockQueryTerm = new QueryTerm();
+
+		mockQueryTerm.setUuid(null);
+		mockQueryTerm.setType("string");
+		mockQueryTerm.setEntity("SavedSegment");
+		mockQueryTerm.setOperator("contains");
+		mockQueryTerm.setValue(new String[]{"FOO"});
+		mockQueryTerm.setField("rawMessage");
+
+		List<QueryEntity> mockQTList = new ArrayList<>();
+		mockQTList.add(mockQueryTerm);
+
+		mockQueryObject.setCondition("AND");
+		mockQueryObject.setRules(mockQTList);
+
+		String query = JPQLGenerator.generateQuery(mockQueryObject, EntityEnum.PASSENGER);
+		Assert.assertEquals(expectedQuery, query);
+	}
 	@Test
 	public void testNotInWhereClauseForDocument() throws InvalidQueryRepositoryException {
 		String expectedQuery = "select distinct p.id, p, p.flight from Passenger p " +

--- a/gtas-parent/gtas-loader/src/main/java/gov/gtas/services/GtasLoaderImpl.java
+++ b/gtas-parent/gtas-loader/src/main/java/gov/gtas/services/GtasLoaderImpl.java
@@ -200,28 +200,27 @@ public class GtasLoaderImpl implements GtasLoader {
 		pnr.setPhones(null);
 		pnr.setDwellTimes(null);
 		pnr.setPaymentForms(null);
-		String stacktrace = ErrorUtils.getStacktrace(e);
-		pnr.setError(stacktrace);
+		pnr.setError(e.toString());
 		if (e instanceof DuplicateHashCodeException) {
 			logger.info(e.getMessage());
 			pnr.getStatus().setMessageStatusEnum(MessageStatusEnum.DUPLICATE_MESSAGE);
 		} else {
 			pnr.getStatus().setMessageStatusEnum(MessageStatusEnum.FAILED_LOADING);
-			logger.error(stacktrace);
+			logger.error("Error in gtas Loader", e);
 		}
 	}
 
 
 	public static void handleException(Exception e, ApisMessage apisMessage) {
 		String stacktrace = ErrorUtils.getStacktrace(e);
-		apisMessage.setError(stacktrace);
+		apisMessage.setError(e.toString());
 		apisMessage.setHashCode(null);
 		if (e instanceof DuplicateHashCodeException) {
 			logger.info(e.getMessage());
 			apisMessage.getStatus().setMessageStatusEnum(MessageStatusEnum.DUPLICATE_MESSAGE);
 		} else {
 			apisMessage.getStatus().setMessageStatusEnum(MessageStatusEnum.FAILED_LOADING);
-			logger.error(stacktrace);
+			logger.error("Error in GTASLOADER: ", e);
 		}
 	}
 

--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/edifact/EdifactParser.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/edifact/EdifactParser.java
@@ -101,7 +101,7 @@ public abstract class EdifactParser<T extends MessageVo> {
 	}
 
 	private void parseTrailer() throws ParseException {
-		getMandatorySegment(UNT.class);
+		getConditionalSegment(UNT.class);
 		getConditionalSegment(UNE.class);
 		getMandatorySegment(UNZ.class);
 	}
@@ -166,6 +166,7 @@ public abstract class EdifactParser<T extends MessageVo> {
 			Segment s = iter.next();
 			if (expectedName.equals(s.getName())) {
 				S rv = segmentFactory.build(s, clazz);
+				rv.setText(s.getText());
 				return rv;
 			} else {
 				if (mandatory) {

--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/pnrgov/PnrUtils.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/pnrgov/PnrUtils.java
@@ -475,7 +475,11 @@ public class PnrUtils {
 	public static List<DocumentVo> convertDocVoFromDoco(List<SSRDoco> ssrDocos) {
 		List<DocumentVo> docList = new ArrayList<DocumentVo>();
 		for (SSRDoco ssrDoco : ssrDocos) {
-			docList.add(new DocumentVo(ssrDoco));
+			try {
+				docList.add(new DocumentVo(ssrDoco));
+			} catch (Exception e ){
+				logger.error("Unable to make an SSRDoc!");
+			}
 		}
 		return docList;
 	}

--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/vo/PnrVo.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/vo/PnrVo.java
@@ -5,11 +5,9 @@
  */
 package gov.gtas.parsers.vo;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
+import gov.gtas.model.SavedSegment;
 import gov.gtas.parsers.pnrgov.segment.TVL_L0;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -36,6 +34,7 @@ public class PnrVo extends MessageVo implements Validatable {
 	private String formOfPayment;
 	private TVL_L0 primeFlight;
 	private Integer daysBookedBeforeTravel;
+	private final Set<SavedSegmentVo> savedSegments = new HashSet<>();
 
 	private List<PassengerVo> passengers = new ArrayList<>();
 	private List<BagMeasurementsVo> bagMeasurements = new ArrayList<>();
@@ -49,6 +48,11 @@ public class PnrVo extends MessageVo implements Validatable {
 	private List<PaymentFormVo> FormOfPayments = new ArrayList<>();
 	private Date reservationCreateDate;
 	private Boolean headPool = Boolean.FALSE;
+
+
+	public Set<SavedSegmentVo> getSavedSegments() {
+		return savedSegments;
+	}
 
 	public double getTotal_bag_weight() {
 		return total_bag_weight;

--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/vo/SavedSegmentVo.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/vo/SavedSegmentVo.java
@@ -1,0 +1,54 @@
+package gov.gtas.parsers.vo;
+
+import java.util.Objects;
+
+public class SavedSegmentVo {
+
+    private String segmentName;
+    private String segmentText;
+    private String regex;
+
+    public SavedSegmentVo(String segmentName, String segmentText, String pattern) {
+        this.segmentName = segmentName;
+        this.segmentText = segmentText;
+        this.regex = pattern;
+    }
+
+    public String getSegmentName() {
+        return segmentName;
+    }
+
+    public void setSegmentName(String segmentName) {
+        this.segmentName = segmentName;
+    }
+
+    public String getSegmentText() {
+        return segmentText;
+    }
+
+    public void setSegmentText(String segmentText) {
+        this.segmentText = segmentText;
+    }
+
+    public String getRegex() {
+        return regex;
+    }
+
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SavedSegmentVo that = (SavedSegmentVo) o;
+        return Objects.equals(segmentName, that.segmentName) &&
+                Objects.equals(segmentText, that.segmentText);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(segmentName, segmentText);
+    }
+}

--- a/gtas-parent/gtas-parsers/src/test/java/gov/gtas/parsers/pnrgov/PnrGovParserTest.java
+++ b/gtas-parent/gtas-parsers/src/test/java/gov/gtas/parsers/pnrgov/PnrGovParserTest.java
@@ -21,10 +21,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.List;
+import java.util.*;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
 
@@ -238,4 +236,28 @@ public class PnrGovParserTest implements ParserTestHelper {
 		PnrVo vo = this.parser.parse(pnrExample);
 		assertNotNull(vo);
 	}
+
+    @Test
+    public void additionalFields() throws IOException, URISyntaxException, ParseException {
+        List<String> fields = new ArrayList<>();
+        fields.add("IFT");
+        List<Pattern> patterns = new ArrayList<>();
+        patterns.add(Pattern.compile("[\\s\\S]*"));
+        PnrGovParser pnrGovParser = new PnrGovParser(fields, patterns);
+        String pnrExample = getMessageText(PNR_META_CHARACTERS);
+        PnrVo vo = pnrGovParser.parse(pnrExample);
+        assertEquals(4, vo.getSavedSegments().size());
+    }
+
+    @Test
+    public void additionalFieldsRegexed() throws IOException, URISyntaxException, ParseException {
+        List<String> fields = new ArrayList<>();
+        fields.add("IFT");
+        List<Pattern> patterns = new ArrayList<>();
+        patterns.add(Pattern.compile("AA 1A-IP"));
+        PnrGovParser pnrGovParser = new PnrGovParser(fields, patterns);
+        String pnrExample = getMessageText(PNR_META_CHARACTERS);
+        PnrVo vo = pnrGovParser.parse(pnrExample);
+        assertEquals(1, vo.getSavedSegments().size());
+    }
 }

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/bo/match/PnrSegmentLink.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/bo/match/PnrSegmentLink.java
@@ -1,0 +1,15 @@
+package gov.gtas.bo.match;
+
+import java.io.Serializable;
+
+public class PnrSegmentLink extends  PnrAttributeLink implements Serializable {
+    private static final long serialVersionUID = -784332;
+
+    public PnrSegmentLink(final long pnrId, final long segmentId) {
+        super(pnrId, segmentId);
+    }
+
+    public long getLinkAttributeId() {
+        return super.getLinkAttributeId();
+    }
+}

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/DrlRuleFileBuilder.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/DrlRuleFileBuilder.java
@@ -34,7 +34,7 @@ public class DrlRuleFileBuilder {
 			PassengerTripDetails.class, Document.class, Pnr.class, Address.class, Phone.class, Email.class,
 			FrequentFlyer.class, CreditCard.class, BookingDetail.class, Agency.class, DwellTime.class, FlightPax.class,
 			Bag.class, PnrAddressLink.class, PnrCreditCardLink.class, PnrEmailLink.class, PnrFrequentFlyerLink.class,
-			PnrBookingLink.class, PnrPassengerLink.class, PnrPhoneLink.class, PnrTravelAgencyLink.class,
+			PnrBookingLink.class, PnrPassengerLink.class, PnrSegmentLink.class, SavedSegment.class, PnrPhoneLink.class, PnrTravelAgencyLink.class,
 			PnrDwellTimeLink.class, Seat.class, PaymentForm.class, MutableFlightDetails.class,
 			PnrFormOfPaymentLink.class, FlightPassengerLink.class };
 

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/RuleConditionBuilder.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/RuleConditionBuilder.java
@@ -333,6 +333,7 @@ public class RuleConditionBuilder {
 			case ADDRESS:
 			case BOOKING_DETAIL:
 			case CREDIT_CARD:
+			case SAVED_SEGMENT:
 				pnrRuleConditionBuilder.addRuleCondition(attributeType, opCode, trm);
 				break;
 			case HITS:

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/pnr/PnrRuleConditionBuilder.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/pnr/PnrRuleConditionBuilder.java
@@ -25,6 +25,7 @@ import static gov.gtas.rule.builder.util.ConditionBuilderUtils.handleMultipleObj
 public class PnrRuleConditionBuilder {
 	private List<AddressConditionBuilder> addressConditionBuilder = new ArrayList<>();
 	private List<PhoneConditionBuilder> phoneConditionBuilder = new ArrayList<>();
+	private List<SegmentConditionBuilder> segmentConditionBuilder = new ArrayList<>();
 	private List<EmailConditionBuilder> emailConditionBuilder = new ArrayList<>();
 	private List<CreditCardConditionBuilder> creditCardConditionBuilder = new ArrayList<>();
 	private List<FrequentFlyerConditionBuilder> frequentFlyerConditionBuilder = new ArrayList<>();
@@ -89,6 +90,12 @@ public class PnrRuleConditionBuilder {
 				ecb.setGroupNumber(groupNumber);
 				conditionBuilderMap.put(uuid, ecb);
 				phoneConditionBuilder.add((PhoneConditionBuilder) ecb);
+				break;
+			case SAVED_SEGMENT:
+				groupNumber = conditionBuilderMap.size() + 1;
+				ecb = getEntityConditionBuilder(entityEnum, groupNumber);
+				conditionBuilderMap.put(uuid, ecb);
+				segmentConditionBuilder.add((SegmentConditionBuilder) ecb);	ecb.setGroupNumber(groupNumber);
 				break;
 			case EMAIL:
 				groupNumber = conditionBuilderMap.size() + 1;
@@ -156,6 +163,9 @@ public class PnrRuleConditionBuilder {
 		case FORM_OF_PAYMENT:
 			ecb = new PaymentFormConditionBuilder(drlVariableName);
 			break;
+		case SAVED_SEGMENT:
+			ecb = new SegmentConditionBuilder(drlVariableName);
+			break;
 		case PNR:
 		case FLIGHT_PAX:
 		case HITS:
@@ -189,6 +199,12 @@ public class PnrRuleConditionBuilder {
 		if (!phoneConditionBuilder.isEmpty()) {
 			for (PhoneConditionBuilder pcb : phoneConditionBuilder) {
 				addLinkCondition(linkStringBuilder, pcb.getLinkVariableName(), PnrPhoneLink.class.getSimpleName(),
+						pnrVarName);
+			}
+		}
+		if (!segmentConditionBuilder.isEmpty()) {
+			for (SegmentConditionBuilder sbc : segmentConditionBuilder) {
+				addLinkCondition(linkStringBuilder, sbc.getLinkVariableName(), PnrSegmentLink.class.getSimpleName(),
 						pnrVarName);
 			}
 		}
@@ -282,6 +298,9 @@ public class PnrRuleConditionBuilder {
 		for (PhoneConditionBuilder pCb : phoneConditionBuilder) {
 			parentStringBuilder.append(pCb.build());
 		}
+		for (SegmentConditionBuilder scb : segmentConditionBuilder) {
+			parentStringBuilder.append(scb.build());
+		}
 		for (EmailConditionBuilder eCb : emailConditionBuilder) {
 			parentStringBuilder.append(eCb.build());
 		}
@@ -316,6 +335,7 @@ public class PnrRuleConditionBuilder {
 	public void reset() {
 		addressConditionBuilder = new ArrayList<>();
 		phoneConditionBuilder = new ArrayList<>();
+		segmentConditionBuilder = new ArrayList<>();
 		emailConditionBuilder = new ArrayList<>();
 		creditCardConditionBuilder = new ArrayList<>();
 		travelAgencyConditionBuilder = new ArrayList<>();
@@ -353,6 +373,7 @@ public class PnrRuleConditionBuilder {
 			case CREDIT_CARD:
 			case TRAVEL_AGENCY:
 			case DWELL_TIME:
+			case SAVED_SEGMENT:
 			case FREQUENT_FLYER:
 				conditionBuilderMap.get(trm.getUuid()).addCondition(opCode, trm.getField(), attributeType,
 						trm.getValue());
@@ -390,6 +411,7 @@ public class PnrRuleConditionBuilder {
 	private void handleMultiVariableObjects() {
 		handleMultipleObjectTypeOnSameRule(addressConditionBuilder);
 		handleMultipleObjectTypeOnSameRule(phoneConditionBuilder);
+		handleMultipleObjectTypeOnSameRule(segmentConditionBuilder);
 		handleMultipleObjectTypeOnSameRule(emailConditionBuilder);
 		handleMultipleObjectTypeOnSameRule(creditCardConditionBuilder);
 		handleMultipleObjectTypeOnSameRule(frequentFlyerConditionBuilder);
@@ -414,5 +436,13 @@ public class PnrRuleConditionBuilder {
 
 	public String getSeatVarName() {
 		return pnrSeatConditionBuilder.getDrlVariableName();
+	}
+
+	public List<SegmentConditionBuilder> getSegmentConditionBuilder() {
+		return segmentConditionBuilder;
+	}
+
+	public void setSegmentConditionBuilder(List<SegmentConditionBuilder> segmentConditionBuilder) {
+		this.segmentConditionBuilder = segmentConditionBuilder;
 	}
 }

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/pnr/SegmentConditionBuilder.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/rule/builder/pnr/SegmentConditionBuilder.java
@@ -1,0 +1,34 @@
+package gov.gtas.rule.builder.pnr;
+
+import gov.gtas.enumtype.CriteriaOperatorEnum;
+import gov.gtas.enumtype.EntityEnum;
+import gov.gtas.enumtype.TypeEnum;
+import gov.gtas.rule.builder.EntityConditionBuilder;
+
+import java.text.ParseException;
+
+import static gov.gtas.rule.builder.RuleTemplateConstants.LINK_VARIABLE_SUFFIX;
+
+public class SegmentConditionBuilder  extends EntityConditionBuilder {
+
+    public SegmentConditionBuilder(final String drlVariableName) {
+        super(drlVariableName, EntityEnum.SAVED_SEGMENT.getEntityName());
+    }
+
+    @Override
+    protected void addSpecialConditions(StringBuilder bldr) {
+    }
+
+    public String getLinkVariableName() {
+        return getDrlVariableName() + LINK_VARIABLE_SUFFIX;
+    }
+
+    @Override
+    public void addCondition(final CriteriaOperatorEnum opCode, final String attributeName,
+                             final TypeEnum attributeType, String[] values) throws ParseException {
+        if (this.isEmpty()) {
+            this.addConditionAsString("id == " + this.getLinkVariableName() + ".linkAttributeId");
+        }
+        super.addCondition(opCode, attributeName, attributeType, values);
+    }
+}

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/svc/request/builder/RuleEngineRequestBuilder.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/svc/request/builder/RuleEngineRequestBuilder.java
@@ -43,6 +43,7 @@ public class RuleEngineRequestBuilder {
 	private Set<Long> flightIdSet;
 	private Set<Long> addressIdSet;
 	private Set<Long> phoneIdSet;
+	private Set<Long> segmentIdSet;
 	private Set<Long> emailIdSet;
 	private Set<Long> creditCardIdSet;
 	private Set<Long> frequentFlyerIdSet;
@@ -52,6 +53,7 @@ public class RuleEngineRequestBuilder {
 	private Set<Long> bookingDetailIdSet;
 	private Set<PnrAddressLink> addressLinks;
 	private Set<PnrPhoneLink> phoneLinks;
+	private Set<PnrSegmentLink> segmentLinks;
 	private Set<PnrEmailLink> emailLinks;
 	private Set<PnrCreditCardLink> creditCardLinks;
 	private Set<PnrFrequentFlyerLink> frequentFlyerLinks;
@@ -101,6 +103,8 @@ public class RuleEngineRequestBuilder {
 		this.frequentFlyerIdSet = new HashSet<>();
 		this.passengerLinkSet = new HashSet<>();
 		this.phoneIdSet = new HashSet<>();
+		this.segmentIdSet = new HashSet<>();
+		this.segmentLinks = new HashSet<>();
 		this.travelAgencyIdSet = new HashSet<>();
 		this.passengerFlightSet = new HashSet<>();
 		this.flightPassengerLinks = new HashSet<>();
@@ -142,6 +146,8 @@ public class RuleEngineRequestBuilder {
 		this.frequentFlyerIdSet = new HashSet<>();
 		this.passengerLinkSet = new HashSet<>();
 		this.phoneIdSet = new HashSet<>();
+		this.segmentIdSet = new HashSet<>();
+		this.segmentLinks = new HashSet<>();
 		this.travelAgencyIdSet = new HashSet<>();
 		this.passengerFlightSet = new HashSet<>();
 		this.flightPassengerLinks = new HashSet<>();
@@ -230,6 +236,7 @@ public class RuleEngineRequestBuilder {
 		Map<Long, Set<Address>> addressObjects = pnrService.createAddressMap(pnrIds);
 		Map<Long, Set<Phone>> phoneObjects = pnrService.createPhoneMap(pnrIds);
 		Map<Long, Set<Email>> emailsObjects = pnrService.createEmailMap(pnrIds);
+		Map<Long, Set<SavedSegment>> segmentObjects  = pnrService.createSegmentMap(pnrIds);
 		Map<Long, Set<CreditCard>> creditCardObjects = pnrService.createCreditCardMap(pnrIds);
 		Map<Long, Set<BookingDetail>> bookingDetailObjects = pnrService.createBookingDetailMap(pnrIds);
 		Map<Long, Set<FrequentFlyer>> frequentFlyerObjects = pnrService.createFrequentFlyersMap(pnrIds);
@@ -322,6 +329,7 @@ public class RuleEngineRequestBuilder {
 			addBookingDetailObjects(pnrId, bookingDetailObjects.get(pnrId));
 			addCreditCardObjects(pnrId, creditCardObjects.get(pnrId));
 			addEmailObjects(pnrId, emailsObjects.get(pnrId));
+			addSegmentLinkObjects(pnrId, segmentObjects.get(pnrId));
 			addPhoneObjects(pnrId, phoneObjects.get(pnrId));
 			addTravelAgencyObjects(pnrId, travelAgency.get(pnrId));
 			addDwellTimeObjects(pnrId, dwellMap.get(pnrId));
@@ -468,6 +476,26 @@ public class RuleEngineRequestBuilder {
 			if (!phoneLinks.contains(pnrPhoneLink)) {
 				requestObjectList.add(pnrPhoneLink);
 				phoneLinks.add(pnrPhoneLink);
+			}
+		}
+	}
+
+
+	private void addSegmentLinkObjects(Long pnrId, Set<SavedSegment> savedSegments) {
+		if (savedSegments == null || savedSegments.isEmpty()) {
+			logger.debug("No saved segments.");
+			return;
+		}
+		for (SavedSegment ss : savedSegments) {
+			Long id = ss.getId();
+			if (!this.segmentIdSet.contains(id)) {
+				requestObjectList.add(ss);
+				this.segmentIdSet.add(id);
+			}
+			PnrSegmentLink pnrSegmentLink = new PnrSegmentLink(pnrId, ss.getId());
+			if (!segmentLinks.contains(pnrSegmentLink)) {
+				requestObjectList.add(pnrSegmentLink);
+				segmentLinks.add(pnrSegmentLink);
 			}
 		}
 	}

--- a/gtas-parent/gtas-webapp/src/main/webapp/data/entities.json
+++ b/gtas-parent/gtas-webapp/src/main/webapp/data/entities.json
@@ -1391,7 +1391,44 @@
       }
     ]
   },
-   "DwellTime": {
+  "SavedSegment": {
+    "label": "SAVED_SEGMENT",
+    "columns": [
+      {
+        "id": "SavedSegment.segmentName",
+        "label": "Segment Name",
+        "type": "string",
+        "operators": [
+          "EQUAL",
+          "NOT_EQUAL",
+          "IN",
+          "NOT_IN"
+        ]
+      },
+      {
+        "id": "SavedSegment.regex",
+        "label": "Regex",
+        "type": "string",
+        "operators": [
+          "EQUAL",
+          "NOT_EQUAL",
+          "CONTAINS",
+          "NOT_CONTAINS"
+        ]
+      },
+      {
+        "id": "SavedSegment.rawSegment",
+        "label": "Raw Segment",
+        "type": "string",
+        "operators": [
+          "CONTAINS",
+          "NOT_CONTAINS"
+        ]
+      }
+    ]
+  },
+
+  "DwellTime": {
     "label": "DWELL TIME",
     "columns": [
       {

--- a/gtas-parent/scripts/db/2.0/saved_segment_rollback.sql
+++ b/gtas-parent/scripts/db/2.0/saved_segment_rollback.sql
@@ -1,0 +1,1 @@
+drop table if exists saved_segment;

--- a/gtas-parent/scripts/db/2.0/saved_segments.sql
+++ b/gtas-parent/scripts/db/2.0/saved_segments.sql
@@ -1,0 +1,16 @@
+create table saved_segment
+(
+    id bigint unsigned auto_increment
+        primary key,
+    created_at datetime null,
+    created_by varchar(20) null,
+    updated_at datetime null,
+    updated_by varchar(20) null,
+    rawSegment varchar(255) null,
+    regex varchar(255) null,
+    segmentName varchar(255) null,
+    pnr_id bigint unsigned null,
+    constraint FKc3mexjuclbkibbah2ddrvon06
+        foreign key (pnr_id) references pnr (id)
+);
+


### PR DESCRIPTION
Some of the information GTAS ingest from PNR data consist of free text fields.

It appears that these fields could follow some degree of structure, but this is not defined or enforced in any meaningful way. Because of this, there is no way to reliably extract contact information or other informative pieces.

To allow for more of a manual search of this certain segments, the parser has been enhanced to take a copy of none to all of the segments IFT,SAC,LTS,SSR,EBD, and ADD. To allow selectivity when selecting segments they must match a list of provided regex. Both the segments and the provided regex are defined in the default.application.properties. Note that only the first matching regex will be recorded by the saved segment. By default no segments are saved.

Once the segments have been extracted they are saved to the saved_segments table of GTAS. Rules and queries can be run on the raw messages, the segment name, and the regex that caused the segment to be saved.

Due to the nature of the free text the only query and rule functionality provided is "contains" and "not contains."