### PR TITLE
Adding custom header for API routing for proxy server

### DIFF
--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/common/AppConfiguration.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/common/AppConfiguration.java
@@ -67,7 +67,7 @@ public class AppConfiguration extends WebMvcConfigurerAdapter {
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**").allowedOrigins(uiAddress).allowedMethods("GET", "POST", "OPTIONS", "PUT")
 				.allowedHeaders("Content-Type", "X-Requested-With", "accept", "Access-Control-Request-Method",
-						"Access-Control-Request-Headers", "X-Auth-Token", "X-login-ajax-call")
+						"Access-Control-Request-Headers", "X-Auth-Token", "X-login-ajax-call", "Api-Proxy-Route-To")
 				.exposedHeaders("Access-Control-Allow-Credentials", "Access-Control-Allow-Origin")
 				.allowedMethods("GET","PUT","POST","DELETE","PATCH","OPTIONS")
 				.allowCredentials(true).maxAge(3600);

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/common/AppConfiguration.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/common/AppConfiguration.java
@@ -67,7 +67,7 @@ public class AppConfiguration extends WebMvcConfigurerAdapter {
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**").allowedOrigins(uiAddress).allowedMethods("GET", "POST", "OPTIONS", "PUT")
 				.allowedHeaders("Content-Type", "X-Requested-With", "accept", "Access-Control-Request-Method",
-						"Access-Control-Request-Headers", "X-Auth-Token", "X-login-ajax-call", "Api-Proxy-Route-To")
+						"Access-Control-Request-Headers", "X-Auth-Token", "X-login-ajax-call", "Router")
 				.exposedHeaders("Access-Control-Allow-Credentials", "Access-Control-Allow-Origin")
 				.allowedMethods("GET","PUT","POST","DELETE","PATCH","OPTIONS")
 				.allowCredentials(true).maxAge(3600);


### PR DESCRIPTION
1. A custom header is required for navigating which API to pass requests to via the proxy server in a docker installation

2. Non-docker versions of gtas would fail on requests with new custom header due to CORS restraints. 

3. This adds new header to the cors allowable header mappings.