### PR TITLE
Fixes #585

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserServiceImpl.java
@@ -153,9 +153,8 @@ public class UserServiceImpl implements UserService {
 	}
 
 		/* Update the user password only. */
-	@Transactional
 	public UserData updatePassword(String userId, String password) {
-		User existingUser = fetchUser(userId.toUpperCase());
+		User existingUser = userRepository.findOne(userId.toUpperCase());
 
 			existingUser.setPassword(getEncodedPassword(password));
 
@@ -235,9 +234,8 @@ public class UserServiceImpl implements UserService {
 		Update all user data except the password. The password is handled by a separate function
 	 */
 	@Override
-	@Transactional
 	public UserData updateByAdmin(UserData data) {
-		User entity = fetchUser(data.getUserId());	//returns error if null
+		User entity = userRepository.findOne(data.getUserId());	//returns error if null
 
 		User mappedEntity = userServiceUtil.mapUserEntityFromUserData(data);
 


### PR DESCRIPTION
-fetchUser does not return userGroup (amongst other data points) since it's primarily used for returns where they are not required

-Using fetchUser for updates is insufficient and misses critical data elements that need to remain for any updates.

This was introduced in: 77cd514a66a5e27763ae5fd77049784109af183f