### PR TITLE
rem transactional tags on reads

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/AirportServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/AirportServiceImpl.java
@@ -48,7 +48,6 @@ public class AirportServiceImpl implements AirportService {
   }
 
   @Override
-  @Transactional
   public List<AirportVo> findAll() {
     List<Airport> allAirports = (List<Airport>) airportRepo.findAll();
 
@@ -61,7 +60,6 @@ public class AirportServiceImpl implements AirportService {
     return allAirportVos;
   }
 
-  @Transactional
   public List<AirportVo> findAllUpdated(Date dt) {
     List<Airport> allAirports = (List<Airport>) airportRepo.findAllUpdated(dt);
 
@@ -76,7 +74,7 @@ public class AirportServiceImpl implements AirportService {
   }
 
   @Override
-  @Transactional
+  @Deprecated
   public List<AirportLookupVo> getAirportLookup() {
     List<Airport> allAirports = (List<Airport>) airportRepo.findAll();
 
@@ -98,7 +96,6 @@ public class AirportServiceImpl implements AirportService {
   }
 
   @Override
-  @Transactional
   public AirportVo findById(Long id) {
     Airport airport = airportRepo.findOne(id);
 
@@ -124,7 +121,6 @@ public class AirportServiceImpl implements AirportService {
   }
 
   @Override
-  @Transactional
   @Cacheable(value = "airportCache", key = "#airportCode")
   public AirportVo getAirportByThreeLetterCode(String airportCode) {
     List<Airport> airports = airportRepo.getAirportByThreeLetterCode(airportCode);
@@ -137,7 +133,6 @@ public class AirportServiceImpl implements AirportService {
   }
 
   @Override
-  @Transactional
   @Cacheable(value = "airportCache", key = "#airportCode")
   public AirportVo getAirportByFourLetterCode(String airportCode) {
     List<Airport> airports = airportRepo.getAirportByFourLetterCode(airportCode);

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/CarrierServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/CarrierServiceImpl.java
@@ -47,7 +47,6 @@ public class CarrierServiceImpl implements CarrierService {
   }
 
   @Override
-  @Transactional
   public List<CarrierVo> findAll() {
 
     List<Carrier> allCarriers = (List<Carrier>) carrierRespository.findAll();
@@ -61,7 +60,6 @@ public class CarrierServiceImpl implements CarrierService {
     return allCarrierVos;
   }
 
-  @Transactional
   public List<CarrierVo> findAllUpdated(Date dt) {
     List<Carrier> allCarriers = (List<Carrier>) carrierRespository.findAllUpdated(dt);
 
@@ -85,7 +83,6 @@ public class CarrierServiceImpl implements CarrierService {
   }
 
   @Override
-  @Transactional
   public CarrierVo findById(Long id) {
     Carrier carrier = carrierRespository.findById(id).orElse(null);
 
@@ -97,7 +94,7 @@ public class CarrierServiceImpl implements CarrierService {
   }
 
   @Override
-  @Transactional
+  @Deprecated
   public List<CarrierLookupVo> getCarrierLookup() {
     List<Carrier> carriers = (List<Carrier>) carrierRespository.findAll();
     List<CarrierLookupVo> allCarrierVos = new ArrayList<>();
@@ -124,7 +121,6 @@ public class CarrierServiceImpl implements CarrierService {
   }
 
   @Override
-  @Transactional
   public CarrierVo getCarrierByTwoLetterCode(String carrierCode) {
     List<Carrier> carriers = carrierRespository.getCarrierByTwoLetterCode(carrierCode);
 
@@ -136,7 +132,6 @@ public class CarrierServiceImpl implements CarrierService {
   }
 
   @Override
-  @Transactional
   public CarrierVo getCarrierByThreeLetterCode(String carrierCode) {
     List<Carrier> carriers = carrierRespository.getCarrierByThreeLetterCode(carrierCode);
 

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/CountryServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/CountryServiceImpl.java
@@ -48,7 +48,6 @@ public class CountryServiceImpl implements CountryService {
   }
 
   @Override
-  @Transactional
   public List<CountryVo> findAll() {
     List<Country> allCountries = (List<Country>) countryRepository.findAll();
 
@@ -62,7 +61,6 @@ public class CountryServiceImpl implements CountryService {
 
   }
 
-  @Transactional
   public List<CountryVo> findAllUpdated(Date dt) {
 
     List<Country> allCountries = (List<Country>) countryRepository.findAllUpdated(dt);
@@ -78,7 +76,7 @@ public class CountryServiceImpl implements CountryService {
   }
 
   @Override
-  @Transactional
+  @Deprecated
   public List<CountryLookupVo> getCountryLookup() {
     List<Country> allCountries = (List<Country>) countryRepository.findAll();
     List<CountryLookupVo> allCountryVos = new ArrayList<>();
@@ -99,7 +97,6 @@ public class CountryServiceImpl implements CountryService {
   }
 
   @Override
-  @Transactional
   public CountryVo findById(Long id) {
     Country country = countryRepository.findById(id).orElse(null);
 
@@ -125,7 +122,6 @@ public class CountryServiceImpl implements CountryService {
   }
 
   @Override
-  @Transactional
   @Cacheable(value = "countryCache", key = "#country")
   public CountryVo getCountryByTwoLetterCode(String country) {
     List<Country> countries = countryRepository.getCountryByTwoLetterCode(country);
@@ -138,7 +134,6 @@ public class CountryServiceImpl implements CountryService {
   }
 
   @Override
-  @Transactional
   @Cacheable(value = "countryCache", key = "#country")
   public CountryVo getCountryByThreeLetterCode(String country) {
     List<Country> countries = countryRepository.getCountryByThreeLetterCode(country);

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/CreditCardTypeServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/CreditCardTypeServiceImpl.java
@@ -46,7 +46,6 @@ public class CreditCardTypeServiceImpl implements CreditCardTypeService {
   }
 
   @Override
-  @Transactional
   public List<CreditCardTypeVo> findAll() {
 
     List<CreditCardType> allCreditCardTypes = (List<CreditCardType>) cctypeRespository.findAll();
@@ -60,7 +59,6 @@ public class CreditCardTypeServiceImpl implements CreditCardTypeService {
     return allCreditCardTypeVos;
   }
 
-  @Transactional
   public List<CreditCardTypeVo> findAllUpdated(Date dt) {
     List<CreditCardType> allCreditCardTypes = (List<CreditCardType>) cctypeRespository.findAllUpdated(dt);
 
@@ -82,7 +80,6 @@ public class CreditCardTypeServiceImpl implements CreditCardTypeService {
   }
 
   @Override
-  @Transactional
   public CreditCardTypeVo findById(Long id) {
     CreditCardType cctype = cctypeRespository.findById(id).orElse(null);
 


### PR DESCRIPTION
removed from all gets in the lookup services. Left them on the upserts/deletes in the event Spring requires them.