### PR TITLE
#2019 Update dwell time calculation to correctly track dwell times.

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/DwellTime.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/DwellTime.java
@@ -17,10 +17,17 @@ import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.Transient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Entity
 @Table(name = "dwell_time")
 public class DwellTime implements Serializable {
+	
+	@Transient
+	public static Logger logger = LoggerFactory.getLogger(DwellTime.class);
 
 	private static final long serialVersionUID = 1L;
 
@@ -35,11 +42,14 @@ public class DwellTime implements Serializable {
 		// java.lang.NullPointerException issue #307 code fix
 		if (this.departureTime != null && this.arrivalTime != null) {
 			long diff = this.departureTime.getTime() - this.arrivalTime.getTime();
-			if (diff > 0) {
+			if (diff < 0) {
+				logger.warn("Arrival Time of incoming flight AFTER departure time of outgoing flight. Likely bad data!");
+			}
 				int minutes = (int) TimeUnit.MINUTES.convert(diff, TimeUnit.MILLISECONDS);
 				DecimalFormat df = new DecimalFormat("#.##");
 				this.dwellTime = Double.valueOf(df.format((double) minutes / 60));
-			}
+		} else {
+			logger.warn("Unable to calculate dwell time, etd or eta missing from arriving or departing flight!");
 		}
 	}
 

--- a/gtas-parent/gtas-loader/src/main/java/gov/gtas/services/LoaderUtils.java
+++ b/gtas-parent/gtas-loader/src/main/java/gov/gtas/services/LoaderUtils.java
@@ -412,13 +412,8 @@ public class LoaderUtils {
 	BookingDetail convertFlightVoToBookingDetail(FlightVo fvo) throws ParseException {
 		BookingDetail bD = new BookingDetail();
 		BeanUtils.copyProperties(fvo, bD);
-		String originAirport = bD.getOrigin();
-		String destinationAirport = bD.getDestination();
-		Date utcETDDate = gtasLocalToUTCService.convertFromAirportCode(originAirport, fvo.getLocalEtdDate());
-		Date utcETADate = gtasLocalToUTCService.convertFromAirportCode(destinationAirport, fvo.getLocalEtaDate());
-		bD.setEta(utcETADate);
-		bD.setEtd(utcETDDate);
-
+		bD.setEta(fvo.getUtcEtaDate());
+		bD.setEtd(fvo.getUtcEtdDate());
 		Airport dest = getAirport(fvo.getDestination());
 		String destCountry = null;
 		if (dest != null) {
@@ -458,15 +453,10 @@ public class LoaderUtils {
 	}
 
 	public void setDwellTime(BookingDetail firstBooking, BookingDetail secondBooking, Pnr pnr) {
-		if (firstBooking != null && secondBooking != null
-				&& firstBooking.getDestination().equalsIgnoreCase(secondBooking.getOrigin())
-				&& (firstBooking.getEta() != null && secondBooking.getEtd() != null)) {
-
 			DwellTime d = new DwellTime(firstBooking.getEta(), secondBooking.getEtd(), secondBooking.getOrigin(), pnr);
 			d.setFlyingFrom(firstBooking.getOrigin());
 			d.setFlyingTo(secondBooking.getDestination());
 			pnr.addDwellTime(d);
-		}
 	}
 
 	public void setDwellTime(Flight firstFlight, BookingDetail secondBooking, Pnr pnr) {
@@ -498,7 +488,7 @@ public class LoaderUtils {
 	// The parsed message did not have the flights in proper order for flight leg
 	// generation (needed for dwell time and appropriate display)
 	void sortFlightsByDate(List<FlightVo> flights) {
-		flights.sort(Comparator.comparing(FlightVo::getLocalEtdDate));
+		flights.sort(Comparator.comparing(FlightVo::getUtcEtdDate));
 	}
 
 	/**

--- a/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/vo/FlightVo.java
+++ b/gtas-parent/gtas-parsers/src/main/java/gov/gtas/parsers/vo/FlightVo.java
@@ -33,11 +33,18 @@ public class FlightVo implements Validatable {
 	// THIS IS NOT UTC TIME. LOCAL ETA DATE IS IN WHATEVER LOCAL TIME OF THE AIRPORT
 	// WHERE FLIGHT IS DESTINED TO
 	private Date localEtaDate;
+	
+	// UTC TIME CONVERSIONS HAPPEN IN LOADER *NOT* GTAS PARSER.
+	private Date utcEtdDate;
+
+	// UTC TIME CONVERSIONS HAPPEN IN LOADER *NOT* GTAS PARSER.
+	private Date utcEtaDate;
+	
 	private String marketingFlightNumber;
 	private boolean isCodeShareFlight = false;
 	private boolean isMarketingFlight = false;
 	private String idTag;
-
+	
 	public void setUuid(UUID uuid) {
 		this.uuid = uuid;
 	}
@@ -137,7 +144,24 @@ public class FlightVo implements Validatable {
 	public UUID getUuid() {
 		return uuid;
 	}
+	
+	public Date getUtcEtdDate() {
+		return utcEtdDate;
+	}
 
+	public void setUtcEtdDate(Date utcEtdDate) {
+		this.utcEtdDate = utcEtdDate;
+	}
+
+	public Date getUtcEtaDate() {
+		return utcEtaDate;
+	}
+
+	public void setUtcEtaDate(Date utcEtaDate) {
+		this.utcEtaDate = utcEtaDate;
+	}
+
+	//TODO: CheckEqualityToBD
 	public boolean equalsThisBD(BookingDetail bookingDetail) {
 		return flightNumber != null && flightNumber.equals(bookingDetail.getFlightNumber()) && localEtdDate != null
 				&& DateUtils.stripTime(localEtdDate).equals(bookingDetail.getEtdDate()) && origin != null


### PR DESCRIPTION
Create dwell times even if they have a "negative" time (i.e. the "next"
flight takes off before the first flight lands).

Update loader to calculate UTC times at start of flight vo instead of as
flights and booking details are created. Updated sort to sort on UTC
time instead of local time.