### PR TITLE
User Equality

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/User.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/User.java
@@ -230,7 +230,7 @@ public class User implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.userId.toUpperCase(), this.password, this.firstName, this.lastName, this.active);
+		return Objects.hash(this.userId.toUpperCase());
 	}
 
 	@Override
@@ -245,10 +245,7 @@ public class User implements Serializable {
 
 		User dataTarget = ((User) target);
 
-		return new EqualsBuilder().append(this.userId.toUpperCase(), dataTarget.getUserId().toUpperCase())
-				.append(this.firstName, dataTarget.getFirstName()).append(this.lastName, dataTarget.getLastName())
-				.append(this.password, dataTarget.getPassword()).append(this.active, dataTarget.getActive())
-				.append(this.roles, dataTarget.getRoles()).isEquals();
+		return new EqualsBuilder().append(this.userId.toUpperCase(), dataTarget.getUserId().toUpperCase()).isEquals();
 	}
 
 	@Override


### PR DESCRIPTION
Several collections use user equality and would lose their integrity if
equality was based on name (such as the hit maker or groups part of
users)

#2027 