### PR TITLE
Fix missing flight data from sidebar

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/FlightService.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/FlightService.java
@@ -82,4 +82,7 @@ public interface FlightService {
 	@PreAuthorize(PRIVILEGES_ADMIN_AND_VIEW_FLIGHTS)
 	List<FlightGridVo> convertFlightToFlightGridVo(List<Flight> flights);
 
+	@PreAuthorize(PRIVILEGES_ADMIN_AND_VIEW_FLIGHTS)
+	FlightVo getIndividualFlightInfo(Long flightId);
+
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/FlightServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/FlightServiceImpl.java
@@ -331,6 +331,14 @@ public class FlightServiceImpl implements FlightService {
     List<FlightGridVo> vos = convertFlightToFlightGridVo(flightslist);
     return vos;
   }
+
+  @Override
+  public FlightVo getIndividualFlightInfo(Long flightId){
+		List<Flight> flt = new ArrayList<>();
+		flt.add(flightRespository.findOne(flightId));
+		List<FlightVo> fltVo = convertFlightToFlightVo(flt);
+		return fltVo.get(0);
+  }
   
   @Override
   public List<FlightGridVo> convertFlightToFlightGridVo(List<Flight> flights) {

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/FlightPassengerController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/FlightPassengerController.java
@@ -78,4 +78,10 @@ public class FlightPassengerController {
 		return paxService.getPassengersByCriteria(null, request);
 	}
 
+	@RequestMapping(value = "api/flights/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	public @ResponseBody FlightVo getSingleFlight(@PathVariable(value = "id") Long flightId, HttpServletRequest hsr) {
+		SecurityContextHolder.setContext((SecurityContext) hsr.getSession().getAttribute("SPRING_SECURITY_CONTEXT"));
+		return flightService.getIndividualFlightInfo(flightId);
+	}
+
 }


### PR DESCRIPTION
-navigating to the flightpax page from non-flight paths results in missing data
-added new endpoint to fetch single flightVo given an Id
-Other option was to modify flight pax return, but this seems cleaner and more versatile for potential other uses.

Fixes #727 on GTAS UI side