### PR TITLE
Fix for having Notify User user drop downs abide archived user status

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/security/UserServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Resource;
 import javax.mail.MessagingException;
@@ -119,6 +120,7 @@ public class UserServiceImpl implements UserService {
 	@Transactional
 	public List<UserDisplayData> findAll() {
 		Iterable<User> usersCollection = userRepository.findAll();
+		usersCollection = StreamSupport.stream(usersCollection.spliterator(), false).filter(user -> (!user.getArchived()))::iterator;
 		return userServiceUtil.getUserDataListFromEntityCollection(usersCollection);
 	}
 


### PR DESCRIPTION
-Users in a user group were all being pulled into the notify user action from pax details regardless of whether they were archived or not.
-Fixed by appending a filter to the user collection on getArchived before returning.

Fixes [#681](https://github.com/US-CBP/GTAS-UI/issues/681) on the GTAS UI side