### PR TITLE
Adding new enum and allowing PWL hits to be seen on POE

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/enumtype/LookoutStatusEnum.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/enumtype/LookoutStatusEnum.java
@@ -33,7 +33,9 @@ public enum LookoutStatusEnum {
 
     UNCATEGORIZED("Uncategorized"),
 
-    NOTPROMOTED("Not Promoted");
+    NOTPROMOTED("Not Promoted"),
+
+    DEMOTED("DEMOTED");
 
     private String POEStatus;
 

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/HitViewStatusRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/HitViewStatusRepository.java
@@ -43,8 +43,8 @@ public interface HitViewStatusRepository extends CrudRepository<HitViewStatus, L
             "left join fetch hd.hitMaker hm "
     + " where hvs.userGroup in :userGroups "
     + " AND NOT hvs.hitViewStatusEnum = 'REVIEWED' "
-    + " AND NOT hvs.hitDetail.hitType = 'PWL' "
     + " AND NOT hvs.lookoutStatusEnum = 'NOTPROMOTED' "
+    + " AND NOT hvs.lookoutStatusEnum = 'DEMOTED' "
     + " AND (mf.etd BETWEEN :startDate AND :endDate "
     + " OR mf.eta BETWEEN :startDate AND :endDate)")
     Set<HitViewStatus> findAllWithNotClosedAndWithinRange(@Param("userGroups") Set<UserGroup> userGroups,

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/HitViewStatusRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/HitViewStatusRepository.java
@@ -42,11 +42,10 @@ public interface HitViewStatusRepository extends CrudRepository<HitViewStatus, L
             "left join fetch p.hitDetails hd " +
             "left join fetch hd.hitMaker hm "
     + " where hvs.userGroup in :userGroups "
-    + " AND NOT hvs.hitViewStatusEnum = 'REVIEWED' "
     + " AND NOT hvs.lookoutStatusEnum = 'NOTPROMOTED' "
     + " AND NOT hvs.lookoutStatusEnum = 'DEMOTED' "
-    + " AND (mf.etd BETWEEN :startDate AND :endDate "
-    + " OR mf.eta BETWEEN :startDate AND :endDate)")
+    + " AND ( (f.direction = 'O' AND mf.etd BETWEEN :startDate AND :endDate) "
+    + " OR (f.direction ='I' AND mf.eta BETWEEN :startDate AND :endDate ))")
     Set<HitViewStatus> findAllWithNotClosedAndWithinRange(@Param("userGroups") Set<UserGroup> userGroups,
                                                            @Param("startDate") Date startDate, @Param("endDate") Date endDate);
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/HitViewStatusRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/HitViewStatusRepository.java
@@ -44,8 +44,10 @@ public interface HitViewStatusRepository extends CrudRepository<HitViewStatus, L
     + " where hvs.userGroup in :userGroups "
     + " AND NOT hvs.lookoutStatusEnum = 'NOTPROMOTED' "
     + " AND NOT hvs.lookoutStatusEnum = 'DEMOTED' "
-    + " AND ( (f.direction = 'O' AND mf.etd BETWEEN :startDate AND :endDate) "
-    + " OR (f.direction ='I' AND mf.eta BETWEEN :startDate AND :endDate ))")
+    + " AND (f.direction = 'O' AND mf.etd BETWEEN :startDate AND :endDate) "
+    + " OR (f.direction ='I' AND mf.eta BETWEEN :startDate AND :endDate ) "
+    + " OR (f.direction = 'A' AND (mf.etd BETWEEN :startDate AND :endDate "
+    + " OR mf.eta BETWEEN :startDate AND :endDate))")
     Set<HitViewStatus> findAllWithNotClosedAndWithinRange(@Param("userGroups") Set<UserGroup> userGroups,
                                                            @Param("startDate") Date startDate, @Param("endDate") Date endDate);
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/POEServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/POEServiceImpl.java
@@ -48,9 +48,6 @@ public class POEServiceImpl implements POEService {
     @Autowired
     private UserService userService;
 
-    private static final DateTime inactiveWindowVariable = new DateTime().minusDays(1);
-    private static final DateTime fullyDemoteVariable = new DateTime().minusWeeks(1);
-
     @Override
     public Set<LookoutStatusDTO> getAllTiles(String userId, POETileServiceRequest request) {
         Set<LookoutStatusDTO> tiles = new HashSet<LookoutStatusDTO>();
@@ -160,16 +157,25 @@ public class POEServiceImpl implements POEService {
     }
 
     public boolean lookoutIsMissedOrInactiveAndUpdate(HitViewStatus hvs){
+
+        DateTime inactiveWindowVariable = new DateTime().minusDays(1); //24 hour timer
+        DateTime fullyDemoteVariable = new DateTime().minusWeeks(1); //1 week timer
+        DateTime missedFlightBufferVariable = new DateTime().minusHours(12); //12 hour buffer on missed flights
+
         if(!hvs.getLookoutStatusEnum().name().equals(LookoutStatusEnum.INACTIVE.name())
                 && !hvs.getLookoutStatusEnum().name().equals(LookoutStatusEnum.MISSED.name())
-                && !hvs.getLookoutStatusEnum().name().equals(LookoutStatusEnum.NOTPROMOTED.name())) {
+                && !hvs.getLookoutStatusEnum().name().equals(LookoutStatusEnum.NOTPROMOTED.name())
+                && !hvs.getLookoutStatusEnum().name().equals(LookoutStatusEnum.DEMOTED.name())) {
             Date pastDue = inactiveWindowVariable.toDate();
-            Date alreadyLandedOrLeft = new Date();
+            Date alreadyLandedOrLeft = missedFlightBufferVariable.toDate();
 
             if (hvs.getUpdatedAt() != null && hvs.getUpdatedAt().before(pastDue)) {
                 hvs.setLookoutStatusEnum(LookoutStatusEnum.INACTIVE);
                 return true;
-            } else if (hvs.getPassenger().getFlight().getFlightCountDownView().getCountDownTimer().before(alreadyLandedOrLeft)
+            } else if (hvs.getUpdatedAt() == null && hvs.getCreatedAt().before(pastDue)){ //Stagnant creation
+                hvs.setLookoutStatusEnum(LookoutStatusEnum.INACTIVE);
+                return true;
+            }else if (hvs.getPassenger().getFlight().getFlightCountDownView().getCountDownTimer().before(alreadyLandedOrLeft)
                     && !updatedAfterDepartureOrArrivalTime(hvs)) {
                 hvs.setLookoutStatusEnum(LookoutStatusEnum.MISSED);
                 return true;
@@ -177,7 +183,7 @@ public class POEServiceImpl implements POEService {
         } else if(hvs.getLookoutStatusEnum().name().equals(LookoutStatusEnum.INACTIVE.name())){ //If after a time inactive, demote
             Date demoteDate = fullyDemoteVariable.toDate();
             if(hvs.getUpdatedAt() != null && hvs.getUpdatedAt().before(demoteDate)){
-                hvs.setLookoutStatusEnum(LookoutStatusEnum.NOTPROMOTED);
+                hvs.setLookoutStatusEnum(LookoutStatusEnum.DEMOTED);
             }
             return true;
         }


### PR DESCRIPTION
-PWL was ignored as POE lookout due to their copious volume, added them back to display
-Demoted has been added as an enum to differentiate between automatic removal from POE vs having never been promoted to it in the first place.

Also adds a time buffer to "Missed" flight to give leeway for "Missing" arrivals or departure.

There is a PR on the front end with branch "POEDemotedEnumAndPWLHitDisplayFix" is required to guarantee accurate vetting page results.