### PR TITLE
Fix/unauthed request security

### DIFF
--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/PreauthController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/PreauthController.java
@@ -14,6 +14,8 @@ import gov.gtas.repository.SignupLocationRepository;
 import gov.gtas.services.SignupRequestService;
 import gov.gtas.services.dto.SignupRequestDTO;
 import gov.gtas.services.security.UserService;
+import gov.gtas.services.TranslationService;
+import gov.gtas.vo.TranslationVo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,22 +27,37 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Preauth Controller handles requests that do not require authorization and which are made only from pages
+ * outside the login. All urls beginning with "/api/preauth/" are excluded from spring security (See AppSecurityConfig.java).
+ * 
+ * Only those handlers serving the preauth pages should be placed here, currently:
+ * forgotPassword
+ * forgotUsername
+ * signup
+ * translations (GET only)
+ */
 @RestController
 public class PreauthController {
 
 	private static final Logger logger = LoggerFactory.getLogger(UserController.class);
-	@Autowired
+
+  @Autowired
 	private UserService userService;
 
 	@Autowired
 	private SignupLocationRepository signupLocationRepository;
 
-	@Autowired()
+	@Autowired
 	private SignupRequestService signupRequestService;
+
+  @Autowired
+  private TranslationService translationservice;
 
 	@RequestMapping(method = RequestMethod.POST, value = "/api/preauth/forgotpassword")
 	public JsonServiceResponse forgotPassword(@RequestParam String userId) {
@@ -131,5 +148,13 @@ public class PreauthController {
     session.invalidate();
 		return new JsonServiceResponse(Status.SUCCESS, "You have been logged out");
   }
+
+  // Allows translation fetch for the unauthed pages without exposing other translation endpoints
+  @RequestMapping(method = RequestMethod.GET, value = "/api/preauth/translation/{language}")
+  public List<TranslationVo> getTranslationsByLang(@PathVariable String language) throws IOException {
+
+    return translationservice.getTranslationsByLang(language);
+  }
+
 }
 

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/PreauthController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/PreauthController.java
@@ -1,0 +1,128 @@
+/*
+ * All GTAS code is Copyright 2016, The Department of Homeland Security (DHS), U.S. Customs and Border Protection (CBP).
+ * 
+ * Please see LICENSE.txt for details.
+ */
+package gov.gtas.controller;
+
+import gov.gtas.enumtype.SignupRequestStatus;
+import gov.gtas.enumtype.Status;
+import gov.gtas.json.JsonServiceResponse;
+import gov.gtas.model.SignupLocation;
+import gov.gtas.model.User;
+import gov.gtas.repository.SignupLocationRepository;
+import gov.gtas.services.SignupRequestService;
+import gov.gtas.services.dto.SignupRequestDTO;
+import gov.gtas.services.security.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+public class PreauthController {
+
+	private static final Logger logger = LoggerFactory.getLogger(UserController.class);
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private SignupLocationRepository signupLocationRepository;
+
+	@Autowired()
+	private SignupRequestService signupRequestService;
+
+	@RequestMapping(method = RequestMethod.POST, value = "/api/preauth/forgotpassword")
+	public JsonServiceResponse forgotPassword(@RequestParam String userId) {
+
+		try {
+			User user = userService.fetchUser(userId);
+			userService.forgotPassword(user);
+
+			return new JsonServiceResponse(Status.SUCCESS,
+					"A temporary password has been sent to your email");
+		} catch (Exception e) {
+			return new JsonServiceResponse(Status.FAILURE,
+					"The provided user ID (" + userId + ") is not on the system! ");
+		}
+	}
+
+	@RequestMapping(method = RequestMethod.POST, value = "/api/preauth/forgotusername")
+	public JsonServiceResponse forgotUsername (@RequestParam String userEmail) {
+		try {
+			userService.forgotUsername(userEmail);
+
+			return new JsonServiceResponse(Status.SUCCESS,
+					"Your username has been sent to your email");
+		} catch (Exception e) {
+			return new JsonServiceResponse(Status.FAILURE,
+					"The provided email (" + userEmail + ") is not on the system!" + e);
+		}
+	}
+
+	@PostMapping(value = "/api/preauth/signup")
+	public JsonServiceResponse signup(@RequestBody @Valid SignupRequestDTO signupRequestDTO, BindingResult result) {
+
+		if (result.hasErrors()) {
+			List<String> errors = result.getAllErrors().stream().map(DefaultMessageSourceResolvable::getDefaultMessage)
+					.collect(Collectors.toList());
+			return new JsonServiceResponse(Status.FAILURE, Arrays.toString(errors.toArray()), signupRequestDTO);
+		} else {
+
+			// Check if a user already exists
+			boolean isExistingUser = userService.findById(signupRequestDTO.getUsername()) != null;
+			boolean isExistingRequest = this.signupRequestService.signupRequestExists(signupRequestDTO);
+			if (isExistingRequest) {
+
+				logger.debug("A sign up request with the same email or username already exists - {}",
+						signupRequestDTO.getEmail());
+				return new JsonServiceResponse(Status.FAILURE, "A sign up request with the same email or username already exists", signupRequestDTO);
+			} else if (isExistingUser) {
+				logger.debug("The username is already taken - {}",
+						signupRequestDTO.getUsername());
+				return new JsonServiceResponse(Status.FAILURE, "The username is already taken - " + signupRequestDTO.getUsername(), signupRequestDTO);
+
+			} else {
+
+				signupRequestDTO.setStatus(SignupRequestStatus.NEW);
+				logger.debug("persisting sign up request");
+				signupRequestService.save(signupRequestDTO);
+
+				try {
+					logger.debug("sending confirmation email to {}", signupRequestDTO.getEmail());
+					signupRequestService.sendConfirmationEmail(signupRequestDTO);
+				} catch (Exception e) {
+					String message = "Failed sending sign up confirmation email to:  " + signupRequestDTO.getEmail();
+					logger.error(message, e);
+				}
+
+				try {
+					logger.debug("sending notification email to admin");
+					signupRequestService.sendEmailNotificationToAdmin(signupRequestDTO);
+				} catch (Exception e) {
+					logger.error("Sending email notification to admin failed.", e);
+				}
+
+				return new JsonServiceResponse(Status.SUCCESS, "The request has been submited");
+			}
+		}
+	}
+    
+	@GetMapping(value = "/api/preauth/locations")
+	public ResponseEntity<Object> getAllActivePhysicalLocations() {
+
+		List<SignupLocation> physicalLocations = this.signupLocationRepository.findAllActiveSignupLocations();
+
+		return new ResponseEntity<>(physicalLocations, HttpStatus.OK);
+	}
+}
+

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/PreauthController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/PreauthController.java
@@ -23,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import java.util.Arrays;
 import java.util.List;
@@ -112,7 +113,7 @@ public class PreauthController {
 					logger.error("Sending email notification to admin failed.", e);
 				}
 
-				return new JsonServiceResponse(Status.SUCCESS, "The request has been submited");
+				return new JsonServiceResponse(Status.SUCCESS, "The request has been submitted");
 			}
 		}
 	}
@@ -124,5 +125,11 @@ public class PreauthController {
 
 		return new ResponseEntity<>(physicalLocations, HttpStatus.OK);
 	}
+
+  @GetMapping(value = "api/logout")
+  public JsonServiceResponse logout(HttpSession session) {
+    session.invalidate();
+		return new JsonServiceResponse(Status.SUCCESS, "You have been logged out");
+  }
 }
 

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/UserController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/UserController.java
@@ -203,7 +203,7 @@ public class UserController {
 
 		} catch (Exception e) {
 			return new JsonServiceResponse(Status.FAILURE,
-					"The provided user ID (" + userId + ") is not on the system! " + e);
+					"The provided user ID (" + userId + ") is not on the system!");
 
 		}
 
@@ -219,7 +219,7 @@ public class UserController {
 
 		} catch (Exception e) {
 			return new JsonServiceResponse(Status.FAILURE,
-					"The provided email (" + userEmail + ") is not on the system!" + e);
+					"The provided email (" + userEmail + ") is not on the system!");
 
 		}
 	}

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/UserController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/UserController.java
@@ -199,11 +199,11 @@ public class UserController {
 			userService.forgotPassword(user);
 
 			return new JsonServiceResponse(Status.SUCCESS,
-					"A temporary  password has been sent to your email. Please use your temporary password to access your account!");
+					"A temporary password has been sent to your email");
 
 		} catch (Exception e) {
 			return new JsonServiceResponse(Status.FAILURE,
-					"The provided user ID (" + userId + ") is not on the system!");
+					"The provided user ID (" + userId + ") is not on the system! " + e);
 
 		}
 
@@ -219,7 +219,7 @@ public class UserController {
 
 		} catch (Exception e) {
 			return new JsonServiceResponse(Status.FAILURE,
-					"The provided email (" + userEmail + ") is not on the system!");
+					"The provided email (" + userEmail + ") is not on the system!" + e);
 
 		}
 	}

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
@@ -19,7 +19,9 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
@@ -79,12 +81,16 @@ public class AppSecurityConfig extends WebSecurityConfigurerAdapter {
 		http.csrf().disable();
 
     http.cors()
-    .and().authorizeRequests()
+    .and()
+			.authorizeRequests()
       .antMatchers("/api/authenticate", "/api/preauth/**", "/api/translation/**", "/api/logout")
       .permitAll().anyRequest().authenticated()
+		.and()
+			.exceptionHandling()
+			.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
     .and().formLogin().loginProcessingUrl("/api/authenticate")
       .successHandler((req, res, auth) -> res.setStatus(HttpStatus.NO_CONTENT.value()))
-      .failureHandler(new UrlAuthenticationFailureHandler())
+      .failureHandler(new SimpleUrlAuthenticationFailureHandler())
     .and().logout().logoutUrl("/api/logout").logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.NO_CONTENT))
       .invalidateHttpSession(true).permitAll();
 

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -87,11 +88,11 @@ public class AppSecurityConfig extends WebSecurityConfigurerAdapter {
 
     http.cors()
     .and().authorizeRequests()
-      .antMatchers("/authenticate", "/password-reset", "/signup/**/*", "/forgot-password", "/reset-password")
+      .antMatchers("/authenticate", "/signup/**/*", "/forgot-password", "/reset-password", "/forgot-username", "/api/translation/**")
       .permitAll().anyRequest().authenticated()
-    // .and().formLogin().loginProcessingUrl("/authenticate").usernameParameter("username").passwordParameter("password")
-    //   .successHandler(new AjaxAuthenticationSuccessHandler(savedReqHandler))
-    //   .failureHandler(new UrlAuthenticationFailureHandler())
+    .and().formLogin().loginProcessingUrl("/authenticate")
+      .successHandler((req, res, auth) -> res.setStatus(HttpStatus.NO_CONTENT.value()))
+      .failureHandler(new UrlAuthenticationFailureHandler())
     .and().logout().logoutUrl("/api/logout").invalidateHttpSession(true).permitAll();  // logout on requests to api/logout
 
 		http.sessionManagement().maximumSessions(1).and().sessionCreationPolicy(SessionCreationPolicy.ALWAYS);

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
@@ -46,20 +47,20 @@ public class AppSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Autowired
 	private MaxLoginAuthenticationProvider daoAuthenticationProvider;
 
-	public void configure(WebSecurity web) throws Exception {
-		// web.ignoring().antMatchers("/factory/**/*", "/admin/**/*", "/flights/**/*", "/pax/**/*", "/query-builder/**/*",
-		// 		"/watchlists/**/*", "/build/**/*", "/dashboard/**/*", "/dist/**/*", "/jqb/**/*", "/userSettings/**/*",
-		// 		"/cases/**/*", "/onedaylookout/**/*", "/userlocation/**/*", "/resources/**", "/common/**/*", "/paxdetailreport/**/*",
-		// 		"/login/**", "/admin/**", "/flightdirectionlist/**/*", "/applicationVersionNumber/**/*", "/app.js",
-		// 		"WEB-INF/**/*", "/data/**", "/signup.html", "/signupConfirmation.html","/user/signup/new","/signup/**/*");
+	// public void configure(WebSecurity web) throws Exception {
+	// 	// web.ignoring().antMatchers("/factory/**/*", "/admin/**/*", "/flights/**/*", "/pax/**/*", "/query-builder/**/*",
+	// 	// 		"/watchlists/**/*", "/build/**/*", "/dashboard/**/*", "/dist/**/*", "/jqb/**/*", "/userSettings/**/*",
+	// 	// 		"/cases/**/*", "/onedaylookout/**/*", "/userlocation/**/*", "/resources/**", "/common/**/*", "/paxdetailreport/**/*",
+	// 	// 		"/login/**", "/admin/**", "/flightdirectionlist/**/*", "/applicationVersionNumber/**/*", "/app.js",
+	// 	// 		"WEB-INF/**/*", "/data/**", "/signup.html", "/signupConfirmation.html","/user/signup/new","/signup/**/*");
 
-    web.ignoring().antMatchers("/factory/**/*", "/admin/**/*", "/flights/**/*", "/pax/**/*", "/query-builder/**/*",
-    "/watchlists/**/*", "/build/**/*", "/dashboard/**/*", "/dist/**/*", "/jqb/**/*", "/userSettings/**/*",
-    "/cases/**/*", "/onedaylookout/**/*", "/userlocation/**/*", "/resources/**", "/common/**/*", "/paxdetailreport/**/*",
-    "/login/**", "/admin/**", "/flightdirectionlist/**/*", "/applicationVersionNumber/**/*", "/app.js",
-    "WEB-INF/**/*", "/data/**", "/signup.html", "/signupConfirmation.html","/user/signup/new","/signup/**/*");
+  //   web.ignoring().antMatchers("/factory/**/*", "/admin/**/*", "/flights/**/*", "/pax/**/*", "/query-builder/**/*",
+  //   "/watchlists/**/*", "/build/**/*", "/dashboard/**/*", "/dist/**/*", "/jqb/**/*", "/userSettings/**/*",
+  //   "/cases/**/*", "/onedaylookout/**/*", "/userlocation/**/*", "/resources/**", "/common/**/*", "/paxdetailreport/**/*",
+  //   "/login/**", "/admin/**", "/flightdirectionlist/**/*", "/applicationVersionNumber/**/*", "/app.js",
+  //   "WEB-INF/**/*", "/data/**", "/signup.html", "/signupConfirmation.html","/user/signup/new","/signup/**/*");
 
-	}
+	// }
 
 	@Autowired
 	public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
@@ -77,23 +78,15 @@ public class AppSecurityConfig extends WebSecurityConfigurerAdapter {
 
 		http.csrf().disable();
 
-		// http.cors().and().authorizeRequests()
-		// 		.antMatchers("/resources/*/**", "/resources/**/*", "/resources/**", "/common/**", "/login/**",
-		// 				"/reset.html", "/password-reset", "/authenticate" , "/signup.html", "/user/signup/new","/signup/**/*","/user/signup/**/*", "/forgot-password", "/reset-password")
-		// 		.permitAll().anyRequest().authenticated().and().formLogin().loginProcessingUrl("/authenticate")
-		// 		.usernameParameter("username").passwordParameter("password")
-		// 		.successHandler(new AjaxAuthenticationSuccessHandler(savedReqHandler))
-		// 		.failureHandler(new UrlAuthenticationFailureHandler()).loginPage("/login.html").and().logout()
-		// 		.logoutUrl("/logout").logoutSuccessUrl("/login.html").invalidateHttpSession(true).permitAll();
-
     http.cors()
     .and().authorizeRequests()
-      .antMatchers("/api/authenticate", "/api/preauth/**", "/forgot-password", "/reset-password", "/forgot-username", "/api/translation/**")
+      .antMatchers("/api/authenticate", "/api/preauth/**", "/api/translation/**", "/api/logout")
       .permitAll().anyRequest().authenticated()
-    .and().formLogin().loginProcessingUrl("/authenticate")
+    .and().formLogin().loginProcessingUrl("/api/authenticate")
       .successHandler((req, res, auth) -> res.setStatus(HttpStatus.NO_CONTENT.value()))
       .failureHandler(new UrlAuthenticationFailureHandler())
-    .and().logout().logoutUrl("/api/logout").invalidateHttpSession(true).permitAll();  // logout on requests to api/logout
+    .and().logout().logoutUrl("/api/logout").logoutSuccessHandler(new HttpStatusReturningLogoutSuccessHandler(HttpStatus.NO_CONTENT))
+      .invalidateHttpSession(true).permitAll();
 
 		http.sessionManagement().maximumSessions(1).and().sessionCreationPolicy(SessionCreationPolicy.ALWAYS);
 

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
@@ -49,21 +49,6 @@ public class AppSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Autowired
 	private MaxLoginAuthenticationProvider daoAuthenticationProvider;
 
-	// public void configure(WebSecurity web) throws Exception {
-	// 	// web.ignoring().antMatchers("/factory/**/*", "/admin/**/*", "/flights/**/*", "/pax/**/*", "/query-builder/**/*",
-	// 	// 		"/watchlists/**/*", "/build/**/*", "/dashboard/**/*", "/dist/**/*", "/jqb/**/*", "/userSettings/**/*",
-	// 	// 		"/cases/**/*", "/onedaylookout/**/*", "/userlocation/**/*", "/resources/**", "/common/**/*", "/paxdetailreport/**/*",
-	// 	// 		"/login/**", "/admin/**", "/flightdirectionlist/**/*", "/applicationVersionNumber/**/*", "/app.js",
-	// 	// 		"WEB-INF/**/*", "/data/**", "/signup.html", "/signupConfirmation.html","/user/signup/new","/signup/**/*");
-
-  //   web.ignoring().antMatchers("/factory/**/*", "/admin/**/*", "/flights/**/*", "/pax/**/*", "/query-builder/**/*",
-  //   "/watchlists/**/*", "/build/**/*", "/dashboard/**/*", "/dist/**/*", "/jqb/**/*", "/userSettings/**/*",
-  //   "/cases/**/*", "/onedaylookout/**/*", "/userlocation/**/*", "/resources/**", "/common/**/*", "/paxdetailreport/**/*",
-  //   "/login/**", "/admin/**", "/flightdirectionlist/**/*", "/applicationVersionNumber/**/*", "/app.js",
-  //   "WEB-INF/**/*", "/data/**", "/signup.html", "/signupConfirmation.html","/user/signup/new","/signup/**/*");
-
-	// }
-
 	@Autowired
 	public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
 		auth.authenticationProvider(daoAuthenticationProvider).userDetailsService(userDetailsService)

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
@@ -88,7 +88,7 @@ public class AppSecurityConfig extends WebSecurityConfigurerAdapter {
 
     http.cors()
     .and().authorizeRequests()
-      .antMatchers("/authenticate", "/signup/**/*", "/forgot-password", "/reset-password", "/forgot-username", "/api/translation/**")
+      .antMatchers("/api/authenticate", "/api/preauth/**", "/forgot-password", "/reset-password", "/forgot-username", "/api/translation/**")
       .permitAll().anyRequest().authenticated()
     .and().formLogin().loginProcessingUrl("/authenticate")
       .successHandler((req, res, auth) -> res.setStatus(HttpStatus.NO_CONTENT.value()))

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
@@ -46,11 +46,17 @@ public class AppSecurityConfig extends WebSecurityConfigurerAdapter {
 	private MaxLoginAuthenticationProvider daoAuthenticationProvider;
 
 	public void configure(WebSecurity web) throws Exception {
-		web.ignoring().antMatchers("/factory/**/*", "/admin/**/*", "/flights/**/*", "/pax/**/*", "/query-builder/**/*",
-				"/watchlists/**/*", "/build/**/*", "/dashboard/**/*", "/dist/**/*", "/jqb/**/*", "/userSettings/**/*",
-				"/cases/**/*", "/onedaylookout/**/*", "/userlocation/**/*", "/resources/**", "/common/**/*", "/paxdetailreport/**/*",
-				"/login/**", "/admin/**", "/flightdirectionlist/**/*", "/applicationVersionNumber/**/*", "/app.js",
-				"WEB-INF/**/*", "/data/**", "/signup.html", "/signupConfirmation.html","/user/signup/new","/signup/**/*");
+		// web.ignoring().antMatchers("/factory/**/*", "/admin/**/*", "/flights/**/*", "/pax/**/*", "/query-builder/**/*",
+		// 		"/watchlists/**/*", "/build/**/*", "/dashboard/**/*", "/dist/**/*", "/jqb/**/*", "/userSettings/**/*",
+		// 		"/cases/**/*", "/onedaylookout/**/*", "/userlocation/**/*", "/resources/**", "/common/**/*", "/paxdetailreport/**/*",
+		// 		"/login/**", "/admin/**", "/flightdirectionlist/**/*", "/applicationVersionNumber/**/*", "/app.js",
+		// 		"WEB-INF/**/*", "/data/**", "/signup.html", "/signupConfirmation.html","/user/signup/new","/signup/**/*");
+
+    web.ignoring().antMatchers("/factory/**/*", "/admin/**/*", "/flights/**/*", "/pax/**/*", "/query-builder/**/*",
+    "/watchlists/**/*", "/build/**/*", "/dashboard/**/*", "/dist/**/*", "/jqb/**/*", "/userSettings/**/*",
+    "/cases/**/*", "/onedaylookout/**/*", "/userlocation/**/*", "/resources/**", "/common/**/*", "/paxdetailreport/**/*",
+    "/login/**", "/admin/**", "/flightdirectionlist/**/*", "/applicationVersionNumber/**/*", "/app.js",
+    "WEB-INF/**/*", "/data/**", "/signup.html", "/signupConfirmation.html","/user/signup/new","/signup/**/*");
 
 	}
 
@@ -70,14 +76,23 @@ public class AppSecurityConfig extends WebSecurityConfigurerAdapter {
 
 		http.csrf().disable();
 
-		http.cors().and().authorizeRequests()
-				.antMatchers("/resources/*/**", "/resources/**/*", "/resources/**", "/common/**", "/login/**",
-						"/reset.html", "/password-reset", "/authenticate" , "/signup.html", "/user/signup/new","/signup/**/*","/user/signup/**/*", "/forgot-password", "/reset-password")
-				.permitAll().anyRequest().authenticated().and().formLogin().loginProcessingUrl("/authenticate")
-				.usernameParameter("username").passwordParameter("password")
-				.successHandler(new AjaxAuthenticationSuccessHandler(savedReqHandler))
-				.failureHandler(new UrlAuthenticationFailureHandler()).loginPage("/login.html").and().logout()
-				.logoutUrl("/logout").logoutSuccessUrl("/login.html").invalidateHttpSession(true).permitAll();
+		// http.cors().and().authorizeRequests()
+		// 		.antMatchers("/resources/*/**", "/resources/**/*", "/resources/**", "/common/**", "/login/**",
+		// 				"/reset.html", "/password-reset", "/authenticate" , "/signup.html", "/user/signup/new","/signup/**/*","/user/signup/**/*", "/forgot-password", "/reset-password")
+		// 		.permitAll().anyRequest().authenticated().and().formLogin().loginProcessingUrl("/authenticate")
+		// 		.usernameParameter("username").passwordParameter("password")
+		// 		.successHandler(new AjaxAuthenticationSuccessHandler(savedReqHandler))
+		// 		.failureHandler(new UrlAuthenticationFailureHandler()).loginPage("/login.html").and().logout()
+		// 		.logoutUrl("/logout").logoutSuccessUrl("/login.html").invalidateHttpSession(true).permitAll();
+
+    http.cors()
+    .and().authorizeRequests()
+      .antMatchers("/authenticate", "/password-reset", "/signup/**/*", "/forgot-password", "/reset-password")
+      .permitAll().anyRequest().authenticated()
+    // .and().formLogin().loginProcessingUrl("/authenticate").usernameParameter("username").passwordParameter("password")
+    //   .successHandler(new AjaxAuthenticationSuccessHandler(savedReqHandler))
+    //   .failureHandler(new UrlAuthenticationFailureHandler())
+    .and().logout().logoutUrl("/api/logout").invalidateHttpSession(true).permitAll();  // logout on requests to api/logout
 
 		http.sessionManagement().maximumSessions(1).and().sessionCreationPolicy(SessionCreationPolicy.ALWAYS);
 

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/security/AppSecurityConfig.java
@@ -68,7 +68,7 @@ public class AppSecurityConfig extends WebSecurityConfigurerAdapter {
     http.cors()
     .and()
 			.authorizeRequests()
-      .antMatchers("/api/authenticate", "/api/preauth/**", "/api/translation/**", "/api/logout")
+      .antMatchers("/api/authenticate", "/api/preauth/**", "/api/logout")
       .permitAll().anyRequest().authenticated()
 		.and()
 			.exceptionHandling()


### PR DESCRIPTION
Fixes frontend issue [#808](https://github.com/US-CBP/GTAS-UI/issues/808) and must be paired with frontend PR.

Issue was that some api calls required before login could not be completed unless submitted with a valid session token. This ticket ensures that the pre-authorization calls are exempted, though additional fixes must be made as part of another ticket.

There were issues and old references in the existing security config. This ticket addresses the following:

1. Removed the ``configure`` method for setting exclusion patterns since those are handled in ``configureGlobal``
2. Corrected the exclusion patterns in ``configureGlobal`` to remove unused patterns
3. Changed the default authentication failure response to return no content rather that the spring default login.html page which is unused as it is handled by the react frontend
4. Added a logout handler to terminate the session so the sessionid can't be reused by the browser.
5. Added a preauth controller for all endpoints that do not require authentication.
6. Updated url paths to use the /api prefix as standard.

You can verify the security with curl by sending a valid jsessionid to various preauth and authed endpoints, and by doing a GET against api/logout with a good sessionid and verifying that you get a 401 for subsequent requests with the same id.
