### PR TITLE
De-duplicate Watchlist Items

### DIFF
--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/watchlist/WatchlistItem.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/watchlist/WatchlistItem.java
@@ -14,12 +14,15 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
-@Table(name = "wl_item")
+@Table(name = "wl_item", indexes = {
+		@Index(name = "wl_key_index", columnList= "KEY_STRING")	
+})
 public class WatchlistItem extends HitMaker {
 	private static final long serialVersionUID = 3593L;
 
@@ -40,7 +43,9 @@ public class WatchlistItem extends HitMaker {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "ITM_WL_KB", referencedColumnName = "ID", nullable = true)
 	private KnowledgeBase knowledgeBase;
-
+	
+	@Column(name = "KEY_STRING")
+	private String keyString;
 	
 	public KnowledgeBase getKnowledgeBase() {
 		return knowledgeBase;
@@ -48,6 +53,22 @@ public class WatchlistItem extends HitMaker {
 
 	public void setKnowledgeBase(KnowledgeBase knowledgeBase) {
 		this.knowledgeBase = knowledgeBase;
+	}
+	
+	
+
+	/**
+	 * @return the wlHash
+	 */
+	public String getKeyString() {
+		return keyString;
+	}
+
+	/**
+	 * @param keyString the wlHash to set
+	 */
+	public void setKeyString(String keyString) {
+		this.keyString = keyString;
 	}
 
 	/**
@@ -97,18 +118,16 @@ public class WatchlistItem extends HitMaker {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.itemData);
+		return Objects.hash(this.itemData, this.getHitCategory());
 	}
 
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
-		if (!super.equals(obj))
-			return false;
 		if (getClass() != obj.getClass())
 			return false;
 		final WatchlistItem other = (WatchlistItem) obj;
-		return Objects.equals(this.itemData, other.itemData);
+		return Objects.equals(this.itemData, other.itemData) && Objects.equals(this.getHitCategory(), other.getHitCategory());
 	}
 }

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/watchlist/json/WatchlistItemSpec.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/model/watchlist/json/WatchlistItemSpec.java
@@ -10,6 +10,8 @@ import java.io.Serializable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * The base query condition term.
  */
@@ -19,6 +21,9 @@ public class WatchlistItemSpec implements Serializable {
 	private Long id;
 	private String action;
 	private WatchlistTerm[] terms;
+	
+	@JsonIgnore
+	private String stringKey;
 
 	public WatchlistItemSpec() {
 	}
@@ -27,6 +32,20 @@ public class WatchlistItemSpec implements Serializable {
 		this.id = id;
 		this.action = action;
 		this.terms = terms;
+	}
+	
+	/**
+	 * @return the hashString
+	 */
+	public String getStringKey() {
+		return stringKey;
+	}
+
+	/**
+	 * @param stringKey the hashString to set
+	 */
+	public void setStringKey(String stringKey) {
+		this.stringKey = stringKey;
 	}
 
 	/**

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/watchlist/WatchlistItemRepository.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/repository/watchlist/WatchlistItemRepository.java
@@ -8,6 +8,7 @@ package gov.gtas.repository.watchlist;
 import gov.gtas.model.watchlist.WatchlistItem;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -33,7 +34,10 @@ public interface WatchlistItemRepository
 	public void deleteItemsByWatchlistName(@Param("watchlistName") String watchlistName);
 
 	@Query("SELECT wli from WatchlistItem wli where wli.knowledgeBase.kbName = :kbName")
-	public List<WatchlistItem> findAllWatchlistItemsByKnowledgeBaseName(@Param("kbName") String kbName);
+	public Set<WatchlistItem> findAllWatchlistItemsByKnowledgeBaseName(@Param("kbName") String kbName);
+	
+	@Query("SELECT wli from WatchlistItem wli where wli.keyString = :keyString")
+	public List<WatchlistItem> findWatchlistItemByKeyString(@Param("keyString") String keyString);	
 	
 	default WatchlistItem findOne(Long id) {
 		return findById(id).orElse(null);

--- a/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/watchlist/WatchlistPersistenceServiceImpl.java
+++ b/gtas-parent/gtas-commons/src/main/java/gov/gtas/services/watchlist/WatchlistPersistenceServiceImpl.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -202,10 +201,10 @@ public class WatchlistPersistenceServiceImpl implements WatchlistPersistenceServ
 			List<WatchlistItem> updList = new LinkedList<>();
 			for (WatchlistItem item : createUpdateItems) {
 				if (item.getId() != null) {
-					logRecords.add(createAuditLogRecord(AuditActionType.UPDATE_WL, watchlist, item,
-							WATCHLIST_LOG_UPDATE_MESSAGE, editUser));
 					item.setHitCategory(hc);
 					item.setAuthor(editUser);
+					logRecords.add(createAuditLogRecord(AuditActionType.UPDATE_WL, watchlist, item,
+							WATCHLIST_LOG_UPDATE_MESSAGE, editUser));
 					updList.add(item);
 				} else {
 					item.setAuthor(editUser);

--- a/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/svc/util/WatchlistBuilder.java
+++ b/gtas-parent/gtas-rulesvc/src/main/java/gov/gtas/svc/util/WatchlistBuilder.java
@@ -97,6 +97,7 @@ public class WatchlistBuilder {
 					}
 
 					item.setItemData(json);
+					item.setKeyString(itemSpec.getStringKey());
 					StringBuilder ruleBldr = new StringBuilder();
 					/* List<String> ruleCriteria = */ WatchlistRuleCreationUtil.createWatchlistRule(this.entity,
 							itemSpec.getTerms(), this.getName(), ruleBldr);
@@ -105,6 +106,7 @@ public class WatchlistBuilder {
 					break;
 				case D:
 					item.setId(itemSpec.getId());
+					item.setKeyString(itemSpec.getStringKey());
 					this.deleteList.add(item);
 					break;
 				}

--- a/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/WatchlistManagementController.java
+++ b/gtas-parent/gtas-webapp/src/main/java/gov/gtas/controller/WatchlistManagementController.java
@@ -204,18 +204,19 @@ public class WatchlistManagementController {
 	public ResponseEntity<?> addUpdatePaxWatchlist(@RequestBody WLRequest<PassengerWatchlistItemDto> request) {
 		List<PassengerWatchlistItemDto> wlItems = request.getWlItems();
 		List<JsonServiceResponse> results = new ArrayList<JsonServiceResponse>();
-
+		
 		for (PassengerWatchlistItemDto wlitem : wlItems) {
 			WatchlistSpec wlSpec = new WatchlistSpec("Passenger", "PASSENGER");
 			List<WatchlistTerm> terms = new ArrayList<WatchlistTerm>();
+			String hashString = wlitem.getFirstName() + wlitem.getLastName() + wlitem.getDob() + wlitem.getCategoryId();
 			terms.add(new WatchlistTerm("firstName", "string", wlitem.getFirstName()));
 			terms.add(new WatchlistTerm("lastName", "string", wlitem.getLastName()));
 			terms.add(new WatchlistTerm("dob", "date", wlitem.getDob()));
 			Long categoryId = Long.parseLong(wlitem.getCategoryId());
-
+				
 			WatchlistItemSpec wlItemSpec = new WatchlistItemSpec(request.getId(), request.getAction(),
 					terms.toArray(new WatchlistTerm[0]));
-
+			wlItemSpec.setStringKey(hashString);
 			wlSpec.getWatchlistItems().add(wlItemSpec);
 			JsonServiceResponse result = createUpdateWatchlist(wlSpec, categoryId);
 			results.add(result);
@@ -230,6 +231,7 @@ public class WatchlistManagementController {
 
 		for (DocumentWatchlistItemDto wlitem : wlItems) {
 			WatchlistSpec wlSpec = new WatchlistSpec("Document", "DOCUMENT");
+			String hashId = wlitem.getDocumentType() + wlitem.getDocumentNumber() + wlitem.getCategoryId();
 			List<WatchlistTerm> terms = new ArrayList<WatchlistTerm>();
 			terms.add(new WatchlistTerm("documentType", "string", wlitem.getDocumentType()));
 			terms.add(new WatchlistTerm("documentNumber", "string", wlitem.getDocumentNumber()));
@@ -238,7 +240,7 @@ public class WatchlistManagementController {
 
 			WatchlistItemSpec wlItemSpec = new WatchlistItemSpec(request.getId(), request.getAction(),
 					terms.toArray(new WatchlistTerm[0]));
-
+			wlItemSpec.setStringKey(hashId);
 			wlSpec.getWatchlistItems().add(wlItemSpec);
 
 			JsonServiceResponse result = createUpdateWatchlist(wlSpec, categoryId);
@@ -252,7 +254,7 @@ public class WatchlistManagementController {
 		validateInput(wlSpec);
 		String userId = GtasSecurityUtils.fetchLoggedInUserId();
 		JsonServiceResponse result = watchlistService.createUpdateDeleteWatchlistItems(userId, wlSpec, categoryId);
-		if (categoryId > 0) {
+		if (categoryId > 0 && (result.getStatus() != Status.FAILURE)) {
 			List<Long> ids = (List<Long>) result.getResult();
 			watchlistService.updateWatchlistItemCategory(categoryId, ids.get(0));
 		}

--- a/gtas-parent/scripts/db/Current Release/wl_dedup_update.sql
+++ b/gtas-parent/scripts/db/Current Release/wl_dedup_update.sql
@@ -1,0 +1,4 @@
+alter table wl_item 
+	add column `KEY_STRING` varchar(255) DEFAULT NULL;
+         
+create index wl_key_index on wl_item (KEY_STRING);


### PR DESCRIPTION
The watchlist items all follow the same structure and can be
de-duplicated in the database by saving the components as a string.
There are two unique values

1) first name + lastname + dob + hit category
2) doc number + doc type + hit category

Once the key is saved in the database a quick check can be run against
it and duplicated values can be logged, ignored, and returned with a
duplicate status. This will relieve pressure on the drools engine, which
does not perform well when the several hundred duplicate watchlist items
are included on a knowledge base.