### PR TITLE
Update dependency com.sun.xml.ws:jaxws-ri 2.3.1 -> 2.3.5. Earlier ver…

### DIFF
--- a/gtas-parent/gtas-commons/pom.xml
+++ b/gtas-parent/gtas-commons/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                              http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -317,7 +317,7 @@
 		<dependency>
 			<groupId>com.sun.xml.ws</groupId>
 			<artifactId>jaxws-ri</artifactId>
-			<version>2.3.1</version>
+			<version>2.3.5</version>
 			<type>pom</type>
 		</dependency>
 
@@ -348,7 +348,7 @@
    			 <artifactId>boxable</artifactId>
     		<version>1.5</version>
 		</dependency>
-		
+
 		<dependency>
     			<groupId>org.apache.pdfbox</groupId>
     			<artifactId>pdfbox</artifactId>


### PR DESCRIPTION
…sion has a transitive dependency to commonj.sdo:2.1.1 that is not on Maven Central.